### PR TITLE
test(split): strengthen compute_splits rounding coverage

### DIFF
--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -184,18 +184,22 @@ async def test_compute_splits_three_way_different_groups():
 
 
 async def test_compute_splits_rounding():
-    """Amounts are rounded to 2 decimal places."""
+    """Amounts are rounded to 2 decimal places.
+
+    Use totals whose binary float sum is not exactly the mathematical sum
+    (e.g. 10.1 + 20.2 != 30.3 in IEEE-754) so the test fails if rounding is removed.
+    """
     classified = {
         "items": [
-            {"upc": "A", "description": "X", "total": 10.333, "category": "item"},
-            {"upc": "B", "description": "Y", "total": 20.667, "category": "item"},
+            {"upc": "A", "description": "X", "total": 10.1, "category": "item"},
+            {"upc": "B", "description": "Y", "total": 20.2, "category": "item"},
         ],
     }
     members = {"u1": ["m1"]}
     uses = {"m1": ["A", "B"]}
 
     result = compute_splits(classified, members, uses, "u1")
-    assert result["splits"][0]["amount"] == 31.0
+    assert result["splits"][0]["amount"] == 30.3
 
 
 # --- Total invariant: sum of splits == sum of all classified items ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`test_compute_splits_rounding` used `10.333 + 20.667`, which sums to exactly `31.0` in binary floating point, so the test did not depend on the `round(..., 2)` call in `compute_splits`. The test now uses `10.1` and `20.2`, whose raw sum is `30.299999999999997` in IEEE-754, so the expected `30.3` value only holds when two-decimal rounding is applied.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Docs
- [ ] CI / tooling
- [x] Test

## Checklist

- [x] `uv run pytest --ignore=tests/test_integration.py` passes locally
- [x] `uv run ruff check . && uv run ruff format --check .` passes
- [x] Tests added or updated for all changed behaviour
- [ ] Docs updated if public API or architecture changed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)

Note: In this agent environment `uv` was unavailable. `tests/test_split.py` was run with `PYTHONPATH=.` and `-o addopts= --noconftest` to avoid project-wide coverage and DB fixtures. Ruff was run on `tests/test_split.py` via `python3 -m ruff`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b587932e-4a6d-45bf-b1e8-4f00bcb3af4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b587932e-4a6d-45bf-b1e8-4f00bcb3af4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

