### PR TITLE
ci: add codecov.yml configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 85%
+    patch:
+      default:
+        target: 80%
+
+ignore:
+  - "alembic/**"
+  - "tests/**"


### PR DESCRIPTION
## Summary

Adds `codecov.yml` to configure coverage reporting thresholds.

- Project target: 84%
- Patch target: 80%
- Ignores alembic/ and tests/ from reporting

**To complete Codecov setup:**
1. Go to https://codecov.io and sign in with GitHub
2. Add the `dostarora97/mealsplit-backend` repo
3. Copy the upload token
4. Add it as `CODECOV_TOKEN` in https://github.com/dostarora97/mealsplit-backend/settings/secrets/actions

## Type of change
- [x] CI / tooling