### PR TITLE
docs: add AGENTS.md with Cursor Cloud specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | How to start | Port |
+|---|---|---|
+| FastAPI dev server | `MEALSPLIT_ENV=development uv run uvicorn app.main:app --reload --port 8000` | 8000 |
+| PostgreSQL (dev) | `sudo docker compose up -d postgres` | 5432 |
+| PostgreSQL (test) | `sudo docker compose up -d postgres-test` | 5433 |
+
+### Prerequisites (already installed in snapshot)
+
+- Python 3.14 via deadsnakes PPA (`python3.14`)
+- `uv` package manager (`~/.local/bin/uv`)
+- Docker (with `fuse-overlayfs` storage driver and `iptables-legacy` for nested container support)
+
+### Startup sequence
+
+1. Start Docker daemon: `sudo dockerd &>/tmp/dockerd.log &` (wait ~3s)
+2. Start PostgreSQL containers: `cd /workspace && sudo docker compose up -d postgres postgres-test`
+3. Wait for healthy: `sudo docker compose ps` (both should show "healthy")
+4. Run migrations: `MEALSPLIT_ENV=development uv run alembic upgrade head`
+5. Start dev server: `MEALSPLIT_ENV=development uv run uvicorn app.main:app --reload --port 8000`
+6. Swagger UI at http://localhost:8000/docs
+
+### Key caveats
+
+- **PATH**: `uv` is installed at `~/.local/bin/uv`. Ensure `$HOME/.local/bin` is on PATH.
+- **Docker nested containers**: The VM runs inside a Docker container in Firecracker. Docker requires `fuse-overlayfs` storage driver and `iptables-legacy`. Both are configured in `/etc/docker/daemon.json` and via `update-alternatives`.
+- **`.secrets.toml`**: Must exist (gitignored). Copy from `.secrets.toml.example`. For local dev, the development `SUPABASE_*` values can be placeholders — `DEBUG=true` enables `POST /auth/dev-login` which bypasses real Supabase auth.
+- **Trailing slashes**: FastAPI routes in this project require trailing slashes (e.g. `/api/v1/menu-items/`). Requests without trailing slashes return 307 redirects.
+- **Unit tests** don't need Ollama; LLM calls are mocked. Run with: `uv run pytest --ignore=tests/test_integration.py -v`
+- **Integration tests** require Ollama with `qwen2.5:3b` model running on port 11434. These are typically skipped in Cloud Agent environments.
+- Standard commands for lint, test, build, and run are documented in `CLAUDE.md` and `CONTRIBUTING.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific instructions for future agents. This documents:

- Services overview (FastAPI, PostgreSQL dev/test) with ports
- Prerequisites already installed in the VM snapshot (Python 3.14, uv, Docker)
- Complete startup sequence for the dev environment
- Key caveats: PATH for uv, Docker nested container config, `.secrets.toml` setup, trailing slash requirements, and unit vs integration test distinctions

## Type of change

- [x] Docs

## Checklist

- [x] `uv run pytest --ignore=tests/test_integration.py` passes locally
- [x] `uv run ruff check . && uv run ruff format --check .` passes
- [x] Docs updated if public API or architecture changed
- [x] Commit messages follow [Conventional Commits](https://conventionalcommits.org)

## Evidence

API hello world test showing all services working:

[api_hello_world_test.log](https://cursor.com/agents/bc-2a4ddf7b-3489-46d6-bbbc-396b91de9ead/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_hello_world_test.log)

Swagger UI demo:

[swagger_ui_demo.mp4](https://cursor.com/agents/bc-2a4ddf7b-3489-46d6-bbbc-396b91de9ead/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswagger_ui_demo.mp4)

[Swagger UI overview](https://cursor.com/agents/bc-2a4ddf7b-3489-46d6-bbbc-396b91de9ead/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswagger_ui_overview.webp)
[Dev login response](https://cursor.com/agents/bc-2a4ddf7b-3489-46d6-bbbc-396b91de9ead/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswagger_dev_login_response.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a4ddf7b-3489-46d6-bbbc-396b91de9ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a4ddf7b-3489-46d6-bbbc-396b91de9ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

