### PR TITLE
docs: remove PLAN.md reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,6 @@ Start here to understand the project:
 
 - @docs/architecture.md — data flow, DB schema, auth, AI layer, config, design decisions
 - @CONTRIBUTING.md — prerequisites, quick start, workflow
-- @PLAN.md (in parent dir) — phased modernisation plan with learnings
 
 ## Key files
 


### PR DESCRIPTION
## Summary

Removes the `@PLAN.md (in parent dir)` reference from CLAUDE.md.

The phased modernisation plan lived in the parent workspace which is being retired. Remaining work (Phase 4: Frontend) is now tracked in #32.

## Type of change
- [x] Docs