### PR TITLE
refactor: merge MenuItem recipe+ingredients into body field

### DIFF
--- a/backend/alembic/versions/c7669b264db5_merge_recipe_and_ingredients_into_body.py
+++ b/backend/alembic/versions/c7669b264db5_merge_recipe_and_ingredients_into_body.py
@@ -1,0 +1,51 @@
+"""merge recipe and ingredients into body
+
+Revision ID: c7669b264db5
+Revises: ed05092115ff
+Create Date: 2026-04-12
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c7669b264db5"
+down_revision: str | None = "ed05092115ff"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Add body column with a temporary default
+    op.add_column("menu_items", sa.Column("body", sa.Text(), nullable=False, server_default=""))
+
+    # Backfill: merge recipe + ingredients into body
+    op.execute("UPDATE menu_items SET body = recipe || E'\\n\\n' || ingredients")
+
+    # Remove the server default now that data is backfilled
+    op.alter_column("menu_items", "body", server_default=None)
+
+    # Drop old columns
+    op.drop_column("menu_items", "recipe")
+    op.drop_column("menu_items", "ingredients")
+
+
+def downgrade() -> None:
+    # Re-add old columns
+    op.add_column("menu_items", sa.Column("recipe", sa.Text(), nullable=False, server_default=""))
+    op.add_column(
+        "menu_items", sa.Column("ingredients", sa.Text(), nullable=False, server_default="")
+    )
+
+    # Best-effort split: put everything in recipe, leave ingredients empty
+    op.execute("UPDATE menu_items SET recipe = body, ingredients = ''")
+
+    # Remove server defaults
+    op.alter_column("menu_items", "recipe", server_default=None)
+    op.alter_column("menu_items", "ingredients", server_default=None)
+
+    # Drop body
+    op.drop_column("menu_items", "body")

--- a/backend/app/models/menu_item.py
+++ b/backend/app/models/menu_item.py
@@ -15,8 +15,7 @@ class MenuItem(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(String(255))
-    recipe: Mapped[str] = mapped_column(Text)
-    ingredients: Mapped[str] = mapped_column(Text)
+    body: Mapped[str] = mapped_column(Text)
     created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
     updated_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
     status: Mapped[str] = mapped_column(String(20), default="active")

--- a/backend/app/routes/menu_items.py
+++ b/backend/app/routes/menu_items.py
@@ -19,8 +19,7 @@ async def create_menu_item(
 ):
     item = MenuItem(
         name=data.name,
-        recipe=data.recipe,
-        ingredients=data.ingredients,
+        body=data.body,
         created_by=current_user.id,
         updated_by=current_user.id,
     )
@@ -72,29 +71,6 @@ async def update_menu_item(
     return item
 
 
-@router.post("/{item_id}/fork", response_model=MenuItemResponse, status_code=201)
-async def fork_menu_item(
-    item_id: uuid.UUID,
-    session: SessionDep,
-    current_user: CurrentUser,
-):
-    source = await session.get(MenuItem, item_id)
-    if not source:
-        raise HTTPException(status_code=404, detail="Menu item not found")
-
-    forked = MenuItem(
-        name=source.name,
-        recipe=source.recipe,
-        ingredients=source.ingredients,
-        created_by=current_user.id,
-        updated_by=current_user.id,
-    )
-    session.add(forked)
-    await session.commit()
-    await session.refresh(forked)
-    return forked
-
-
 @router.patch("/{item_id}/archive", response_model=MenuItemResponse)
 async def archive_menu_item(
     item_id: uuid.UUID,
@@ -106,6 +82,23 @@ async def archive_menu_item(
         raise HTTPException(status_code=404, detail="Menu item not found")
 
     item.status = "archived"
+    item.updated_by = current_user.id
+    await session.commit()
+    await session.refresh(item)
+    return item
+
+
+@router.patch("/{item_id}/unarchive", response_model=MenuItemResponse)
+async def unarchive_menu_item(
+    item_id: uuid.UUID,
+    session: SessionDep,
+    current_user: CurrentUser,
+):
+    item = await session.get(MenuItem, item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Menu item not found")
+
+    item.status = "active"
     item.updated_by = current_user.id
     await session.commit()
     await session.refresh(item)

--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -36,7 +36,7 @@ async def _snapshot_meal_plans(
 
     Returns:
         members: {user_id_str: [menu_item_id_str, ...]}
-        menu_items: [{id, name, ingredients}, ...]
+        menu_items: [{id, name, body}, ...]
     """
     members: dict[str, list[str]] = {}
     seen_menu_item_ids: set[uuid.UUID] = set()
@@ -66,7 +66,7 @@ async def _snapshot_meal_plans(
                         {
                             "id": str(mi.id),
                             "name": mi.name,
-                            "ingredients": mi.ingredients,
+                            "body": mi.body,
                         }
                     )
 

--- a/backend/app/schemas/menu_item.py
+++ b/backend/app/schemas/menu_item.py
@@ -6,14 +6,12 @@ from pydantic import BaseModel, ConfigDict
 
 class MenuItemCreate(BaseModel):
     name: str
-    recipe: str
-    ingredients: str
+    body: str
 
 
 class MenuItemUpdate(BaseModel):
     name: str | None = None
-    recipe: str | None = None
-    ingredients: str | None = None
+    body: str | None = None
 
 
 class MenuItemResponse(BaseModel):
@@ -21,10 +19,7 @@ class MenuItemResponse(BaseModel):
 
     id: uuid.UUID
     name: str
-    recipe: str
-    ingredients: str
-    created_by: uuid.UUID
-    updated_by: uuid.UUID
+    body: str
     status: str
     created_at: datetime
     updated_at: datetime

--- a/backend/app/services/correlate.py
+++ b/backend/app/services/correlate.py
@@ -1,18 +1,19 @@
 """
 MenuItem ↔ GroceryItem Correlator
 
-For each MenuItem, sends its name + ingredients alongside the full list of
-GroceryItems to the LLM, which returns the matched UPCs. This builds the
-bipartite adjacency used by the split service.
+For each MenuItem, sends its name + body (recipe and ingredient details)
+alongside the full list of GroceryItems to the LLM, which returns the
+matched UPCs. This builds the bipartite adjacency used by the split service.
 """
 
 from app.ai.client import generate
 
 SYSTEM_PROMPT = (
-    "You match a menu item's ingredients to grocery items from an invoice. "
-    "Given a menu item (name + ingredients) and a list of grocery items (description + UPC), "
+    "You match a menu item to grocery items from an invoice. "
+    "Given a menu item (name + body containing recipe and ingredient details) "
+    "and a list of grocery items (description + UPC), "
     "return the UPCs of grocery items that would be used to prepare this menu item. "
-    "Only match items that are clearly ingredients for the dish. "
+    "Only match items that are clearly needed for the dish. "
     "If no grocery items match, return an empty list."
 )
 
@@ -35,13 +36,13 @@ def _build_grocery_list_text(grocery_items: list[dict]) -> str:
 
 async def _correlate_menu_item(
     menu_item_name: str,
-    menu_item_ingredients: str,
+    menu_item_body: str,
     grocery_list_text: str,
 ) -> list[str]:
-    """Ask LLM to match one MenuItem's ingredients to GroceryItem UPCs."""
+    """Ask LLM to match one MenuItem to GroceryItem UPCs."""
     prompt = (
         f"Menu Item: {menu_item_name}\n"
-        f"Ingredients: {menu_item_ingredients}\n\n"
+        f"Menu Item Details:\n{menu_item_body}\n\n"
         f"Available Grocery Items:\n{grocery_list_text}\n\n"
         f"Which grocery items (by UPC) are used to prepare this menu item?"
     )
@@ -61,7 +62,7 @@ async def correlate(
     """Build uses mapping: menu_item_id → [upc, ...].
 
     Args:
-        menu_items: List of dicts with "id", "name", "ingredients" keys.
+        menu_items: List of dicts with "id", "name", "body" keys.
         grocery_items: List of dicts with "upc", "description" keys
                        (items only, not fees).
 
@@ -75,7 +76,7 @@ async def correlate(
     for item in menu_items:
         matched = await _correlate_menu_item(
             menu_item_name=item["name"],
-            menu_item_ingredients=item["ingredients"],
+            menu_item_body=item["body"],
             grocery_list_text=grocery_list_text,
         )
         uses[str(item["id"])] = [upc for upc in matched if upc in valid_upcs]

--- a/backend/docs/architecture.md
+++ b/backend/docs/architecture.md
@@ -25,7 +25,7 @@ FastAPI (/api/v1/...)
   │
   ├─ /auth/me          → validate JWT, find/create user
   ├─ /users            → CRUD
-  ├─ /menu-items       → CRUD + fork + archive
+  ├─ /menu-items       → CRUD + archive/unarchive
   ├─ /meal-plans       → get/set/add/remove per user
   └─ /orders           → upload PDF → pipeline → splits
        │
@@ -36,7 +36,7 @@ FastAPI (/api/v1/...)
        │
        ├─ 2. _snapshot_meal_plans() → freeze participants' plans at this moment
        │     builds: members = {user_id: [menu_item_ids]}
-       │             menu_items = [{id, name, ingredients}]
+       │             menu_items = [{id, name, body}]
        │
        ├─ 3. extract(pdf_path)      → pdfplumber (sync, via asyncio.to_thread)
        │     parses invoice tables, extracts line items
@@ -47,7 +47,7 @@ FastAPI (/api/v1/...)
        │     returns: {summary: {item_total, fee_total, grand_total}, items: [...]}
        │
        ├─ 5. correlate(menu_items, grocery_items) → LiteLLM → LLM
-       │     for each MenuItem: send name+ingredients + all GroceryItems
+       │     for each MenuItem: send name+body + all GroceryItems
        │     LLM returns matched UPCs
        │     returns: {menu_item_id: [upc, ...]}
        │
@@ -102,9 +102,8 @@ Each group = one split transaction. This is the minimum number of transactions.
 │ email        │◄────│ updated_by (FK)  │
 │ name         │     │ id (UUID PK)     │
 │ phone        │     │ name             │
-│ avatar_url   │     │ recipe (text/md) │
-│ oauth_provider│    │ ingredients (text)│
-│ oauth_id     │     │ status           │
+│ avatar_url   │     │ body (text/md)   │
+│ oauth_provider│    │ status           │
 │ is_active    │     │ created_at       │
 │ created_at   │     │ updated_at       │
 │ updated_at   │     └──────────────────┘

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -89,13 +89,11 @@ async def _login(client: AsyncClient, email: str, name: str) -> tuple[str, str]:
     return resp.json()["access_token"], resp.json()["user"]["id"]
 
 
-async def _create_menu_item(
-    client: AsyncClient, token: str, name: str, recipe: str, ingredients: str
-) -> str:
+async def _create_menu_item(client: AsyncClient, token: str, name: str, body: str) -> str:
     """Create a menu item, return its ID."""
     resp = await client.post(
         "/api/v1/menu-items/",
-        json={"name": name, "recipe": recipe, "ingredients": ingredients},
+        json={"name": name, "body": body},
         headers=_auth(token),
     )
     assert resp.status_code == 201
@@ -215,24 +213,22 @@ async def test_update_other_user_forbidden(client: AsyncClient):
 
 
 async def test_create_menu_item(client: AsyncClient):
-    token, user_id = await _login(client, "chef@test.com", "Chef")
+    token, _ = await _login(client, "chef@test.com", "Chef")
     resp = await client.post(
         "/api/v1/menu-items/",
-        json={"name": "Pasta", "recipe": "Boil pasta.", "ingredients": "pasta, sauce"},
+        json={"name": "Pasta", "body": "Boil pasta.\n\npasta, sauce"},
         headers=_auth(token),
     )
     assert resp.status_code == 201
     data = resp.json()
     assert data["name"] == "Pasta"
     assert data["status"] == "active"
-    assert data["created_by"] == user_id
-    assert data["updated_by"] == user_id
 
 
 async def test_list_menu_items_with_filters(client: AsyncClient):
     token, user_id = await _login(client, "filter@test.com", "Filter")
-    await _create_menu_item(client, token, "Active1", "r", "i")
-    id2 = await _create_menu_item(client, token, "Active2", "r", "i")
+    await _create_menu_item(client, token, "Active1", "body")
+    id2 = await _create_menu_item(client, token, "Active2", "body")
 
     # Archive one
     await client.patch(f"/api/v1/menu-items/{id2}/archive", headers=_auth(token))
@@ -250,12 +246,12 @@ async def test_list_menu_items_with_filters(client: AsyncClient):
 
     # Filter by creator
     resp = await client.get(f"/api/v1/menu-items/?created_by={user_id}")
-    assert all(i["created_by"] == user_id for i in resp.json())
+    assert len(resp.json()) >= 1
 
 
 async def test_get_menu_item_by_id(client: AsyncClient):
     token, _ = await _login(client, "get@test.com", "Get")
-    item_id = await _create_menu_item(client, token, "GetThis", "r", "i")
+    item_id = await _create_menu_item(client, token, "GetThis", "body")
     resp = await client.get(f"/api/v1/menu-items/{item_id}")
     assert resp.status_code == 200
     assert resp.json()["name"] == "GetThis"
@@ -267,45 +263,24 @@ async def test_get_menu_item_not_found(client: AsyncClient):
 
 
 async def test_update_menu_item(client: AsyncClient):
-    token, user_id = await _login(client, "edit@test.com", "Editor")
-    item_id = await _create_menu_item(client, token, "Original", "old recipe", "old ing")
+    token, _ = await _login(client, "edit@test.com", "Editor")
+    item_id = await _create_menu_item(client, token, "Original", "old body")
     resp = await client.patch(
         f"/api/v1/menu-items/{item_id}",
-        json={"name": "Updated", "recipe": "new recipe", "ingredients": "new ing"},
+        json={"name": "Updated", "body": "new body"},
         headers=_auth(token),
     )
     assert resp.status_code == 200
     assert resp.json()["name"] == "Updated"
-    assert resp.json()["recipe"] == "new recipe"
-    assert resp.json()["updated_by"] == user_id
-
-
-async def test_fork_menu_item(client: AsyncClient):
-    token_a, _id_a = await _login(client, "forker_src@test.com", "Source")
-    token_b, id_b = await _login(client, "forker_dst@test.com", "Forker")
-    item_id = await _create_menu_item(client, token_a, "Original", "r", "i")
-
-    resp = await client.post(f"/api/v1/menu-items/{item_id}/fork", headers=_auth(token_b))
-    assert resp.status_code == 201
-    forked = resp.json()
-    assert forked["id"] != item_id
-    assert forked["name"] == "Original"
-    assert forked["created_by"] == id_b
-
-
-async def test_fork_nonexistent_item(client: AsyncClient):
-    token, _ = await _login(client, "fork404@test.com", "Fork404")
-    resp = await client.post(f"/api/v1/menu-items/{uuid.uuid4()}/fork", headers=_auth(token))
-    assert resp.status_code == 404
+    assert resp.json()["body"] == "new body"
 
 
 async def test_archive_menu_item(client: AsyncClient):
-    token, user_id = await _login(client, "archiver@test.com", "Archiver")
-    item_id = await _create_menu_item(client, token, "ToArchive", "r", "i")
+    token, _ = await _login(client, "archiver@test.com", "Archiver")
+    item_id = await _create_menu_item(client, token, "ToArchive", "body")
     resp = await client.patch(f"/api/v1/menu-items/{item_id}/archive", headers=_auth(token))
     assert resp.status_code == 200
     assert resp.json()["status"] == "archived"
-    assert resp.json()["updated_by"] == user_id
 
 
 # ================================================================
@@ -322,8 +297,8 @@ async def test_empty_meal_plan(client: AsyncClient):
 
 async def test_set_meal_plan(client: AsyncClient):
     token, _ = await _login(client, "set_plan@test.com", "Setter")
-    id1 = await _create_menu_item(client, token, "Item1", "r", "i")
-    id2 = await _create_menu_item(client, token, "Item2", "r", "i")
+    id1 = await _create_menu_item(client, token, "Item1", "body")
+    id2 = await _create_menu_item(client, token, "Item2", "body")
 
     resp = await client.put(
         "/api/v1/meal-plans/me",
@@ -346,7 +321,7 @@ async def test_set_meal_plan_nonexistent_item(client: AsyncClient):
 
 async def test_add_item_to_plan(client: AsyncClient):
     token, _ = await _login(client, "add_plan@test.com", "Adder")
-    id1 = await _create_menu_item(client, token, "AddMe", "r", "i")
+    id1 = await _create_menu_item(client, token, "AddMe", "body")
 
     resp = await client.post(
         "/api/v1/meal-plans/me/items",
@@ -359,7 +334,7 @@ async def test_add_item_to_plan(client: AsyncClient):
 
 async def test_add_item_idempotent(client: AsyncClient):
     token, _ = await _login(client, "idem@test.com", "Idem")
-    item_id = await _create_menu_item(client, token, "Idem", "r", "i")
+    item_id = await _create_menu_item(client, token, "Idem", "body")
 
     await client.post(
         "/api/v1/meal-plans/me/items", json={"menu_item_id": item_id}, headers=_auth(token)
@@ -382,8 +357,8 @@ async def test_add_nonexistent_item_to_plan(client: AsyncClient):
 
 async def test_remove_item_from_plan(client: AsyncClient):
     token, _ = await _login(client, "remove@test.com", "Remover")
-    id1 = await _create_menu_item(client, token, "Keep", "r", "i")
-    id2 = await _create_menu_item(client, token, "Remove", "r", "i")
+    id1 = await _create_menu_item(client, token, "Keep", "body")
+    id2 = await _create_menu_item(client, token, "Remove", "body")
 
     await client.put(
         "/api/v1/meal-plans/me",
@@ -400,8 +375,8 @@ async def test_remove_item_from_plan(client: AsyncClient):
 async def test_replace_meal_plan(client: AsyncClient):
     """Setting a plan replaces the previous one entirely."""
     token, _ = await _login(client, "replace@test.com", "Replacer")
-    id1 = await _create_menu_item(client, token, "Old", "r", "i")
-    id2 = await _create_menu_item(client, token, "New", "r", "i")
+    id1 = await _create_menu_item(client, token, "Old", "body")
+    id2 = await _create_menu_item(client, token, "New", "body")
 
     await client.put("/api/v1/meal-plans/me", json={"menu_item_ids": [id1]}, headers=_auth(token))
     resp = await client.put(
@@ -429,18 +404,16 @@ async def test_order_full_pipeline(client: AsyncClient):
         client,
         alice_token,
         "Chicken Curry",
-        "Cook chicken with onions and spices, squeeze lemon.",
-        "boneless chicken breast, onion, lemon, spices",
+        "Cook chicken with onions and spices, squeeze lemon.\n\nboneless chicken breast, onion, lemon, spices",
     )
     salad_id = await _create_menu_item(
         client,
         bob_token,
         "Green Salad",
-        "Chop cucumber and cherry tomatoes, dress with lemon.",
-        "cucumber, cherry tomato, lemon",
+        "Chop cucumber and cherry tomatoes, dress with lemon.\n\ncucumber, cherry tomato, lemon",
     )
     tea_id = await _create_menu_item(
-        client, carol_token, "Milk Tea", "Boil milk with tea leaves.", "milk"
+        client, carol_token, "Milk Tea", "Boil milk with tea leaves.\n\nmilk"
     )
 
     # Set meal plans
@@ -539,7 +512,7 @@ async def test_order_not_participant_forbidden(client: AsyncClient):
     outsider_token, _ = await _login(client, "outsider@test.com", "Outsider")
 
     # Create minimal menu item + plan so pipeline can run
-    item_id = await _create_menu_item(client, alice_token, "Quick", "r", "i")
+    item_id = await _create_menu_item(client, alice_token, "Quick", "body")
     await client.put(
         "/api/v1/meal-plans/me",
         json={"menu_item_ids": [item_id]},

--- a/backend/tests/test_meal_plans.py
+++ b/backend/tests/test_meal_plans.py
@@ -8,7 +8,7 @@ from httpx import AsyncClient
 async def _create_item(client: AsyncClient, auth_headers: dict, name: str = "Item") -> str:
     resp = await client.post(
         "/api/v1/menu-items/",
-        json={"name": name, "recipe": "r", "ingredients": "i"},
+        json={"name": name, "body": "test body"},
         headers=auth_headers,
     )
     return resp.json()["id"]

--- a/backend/tests/test_menu_items.py
+++ b/backend/tests/test_menu_items.py
@@ -10,8 +10,7 @@ async def test_create_menu_item(client: AsyncClient, auth_headers: dict):
         "/api/v1/menu-items/",
         json={
             "name": "Chicken Curry",
-            "recipe": "## Chicken Curry\n\nCook chicken with spices.",
-            "ingredients": "chicken, onion, spices",
+            "body": "## Recipe\nCook chicken with spices.\n\n## Ingredients\nchicken, onion, spices",
         },
         headers=auth_headers,
     )
@@ -24,7 +23,7 @@ async def test_create_menu_item(client: AsyncClient, auth_headers: dict):
 async def test_list_menu_items(client: AsyncClient, auth_headers: dict):
     await client.post(
         "/api/v1/menu-items/",
-        json={"name": "Salad", "recipe": "Chop veggies.", "ingredients": "cucumber, tomato"},
+        json={"name": "Salad", "body": "Chop veggies.\n\ncucumber, tomato"},
         headers=auth_headers,
     )
     response = await client.get("/api/v1/menu-items/")
@@ -35,12 +34,12 @@ async def test_list_menu_items(client: AsyncClient, auth_headers: dict):
 async def test_list_menu_items_filter_by_status(client: AsyncClient, auth_headers: dict):
     await client.post(
         "/api/v1/menu-items/",
-        json={"name": "Active", "recipe": "r", "ingredients": "i"},
+        json={"name": "Active", "body": "active item body"},
         headers=auth_headers,
     )
     resp2 = await client.post(
         "/api/v1/menu-items/",
-        json={"name": "ToArchive", "recipe": "r", "ingredients": "i"},
+        json={"name": "ToArchive", "body": "to archive body"},
         headers=auth_headers,
     )
     await client.patch(f"/api/v1/menu-items/{resp2.json()['id']}/archive", headers=auth_headers)
@@ -58,18 +57,18 @@ async def test_list_menu_items_filter_by_creator(
 ):
     await client.post(
         "/api/v1/menu-items/",
-        json={"name": "Mine", "recipe": "r", "ingredients": "i"},
+        json={"name": "Mine", "body": "my item body"},
         headers=auth_headers,
     )
     response = await client.get(f"/api/v1/menu-items/?created_by={test_user.id}")
     assert response.status_code == 200
-    assert all(i["created_by"] == str(test_user.id) for i in response.json())
+    assert len(response.json()) >= 1
 
 
 async def test_get_menu_item_by_id(client: AsyncClient, auth_headers: dict):
     created = await client.post(
         "/api/v1/menu-items/",
-        json={"name": "GetMe", "recipe": "r", "ingredients": "i"},
+        json={"name": "GetMe", "body": "get me body"},
         headers=auth_headers,
     )
     item_id = created.json()["id"]
@@ -83,24 +82,40 @@ async def test_get_menu_item_not_found(client: AsyncClient):
     assert response.status_code == 404
 
 
-async def test_update_menu_item(client: AsyncClient, auth_headers: dict, test_user):
+async def test_update_menu_item(client: AsyncClient, auth_headers: dict):
     created = await client.post(
         "/api/v1/menu-items/",
-        json={"name": "Before", "recipe": "old", "ingredients": "old"},
+        json={"name": "Before", "body": "old body"},
         headers=auth_headers,
     )
     item_id = created.json()["id"]
 
     response = await client.patch(
         f"/api/v1/menu-items/{item_id}",
-        json={"name": "After", "ingredients": "new"},
+        json={"name": "After", "body": "new body"},
         headers=auth_headers,
     )
     assert response.status_code == 200
     assert response.json()["name"] == "After"
-    assert response.json()["ingredients"] == "new"
-    assert response.json()["recipe"] == "old"  # unchanged
-    assert response.json()["updated_by"] == str(test_user.id)
+    assert response.json()["body"] == "new body"
+
+
+async def test_update_menu_item_partial(client: AsyncClient, auth_headers: dict):
+    created = await client.post(
+        "/api/v1/menu-items/",
+        json={"name": "Original", "body": "original body"},
+        headers=auth_headers,
+    )
+    item_id = created.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/menu-items/{item_id}",
+        json={"name": "Renamed"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "Renamed"
+    assert response.json()["body"] == "original body"  # unchanged
 
 
 async def test_update_menu_item_not_found(client: AsyncClient, auth_headers: dict):
@@ -112,29 +127,10 @@ async def test_update_menu_item_not_found(client: AsyncClient, auth_headers: dic
     assert response.status_code == 404
 
 
-async def test_fork_menu_item(client: AsyncClient, auth_headers: dict):
-    created = await client.post(
-        "/api/v1/menu-items/",
-        json={"name": "Original", "recipe": "Boil.", "ingredients": "pasta, sauce"},
-        headers=auth_headers,
-    )
-    item_id = created.json()["id"]
-
-    fork_resp = await client.post(f"/api/v1/menu-items/{item_id}/fork", headers=auth_headers)
-    assert fork_resp.status_code == 201
-    assert fork_resp.json()["name"] == "Original"
-    assert fork_resp.json()["id"] != item_id
-
-
-async def test_fork_not_found(client: AsyncClient, auth_headers: dict):
-    response = await client.post(f"/api/v1/menu-items/{uuid.uuid4()}/fork", headers=auth_headers)
-    assert response.status_code == 404
-
-
 async def test_archive_menu_item(client: AsyncClient, auth_headers: dict):
     created = await client.post(
         "/api/v1/menu-items/",
-        json={"name": "Soup", "recipe": "Boil.", "ingredients": "veggies"},
+        json={"name": "Soup", "body": "boil veggies"},
         headers=auth_headers,
     )
     item_id = created.json()["id"]
@@ -147,5 +143,26 @@ async def test_archive_menu_item(client: AsyncClient, auth_headers: dict):
 async def test_archive_not_found(client: AsyncClient, auth_headers: dict):
     response = await client.patch(
         f"/api/v1/menu-items/{uuid.uuid4()}/archive", headers=auth_headers
+    )
+    assert response.status_code == 404
+
+
+async def test_unarchive_menu_item(client: AsyncClient, auth_headers: dict):
+    created = await client.post(
+        "/api/v1/menu-items/",
+        json={"name": "Soup", "body": "boil veggies"},
+        headers=auth_headers,
+    )
+    item_id = created.json()["id"]
+
+    await client.patch(f"/api/v1/menu-items/{item_id}/archive", headers=auth_headers)
+    response = await client.patch(f"/api/v1/menu-items/{item_id}/unarchive", headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json()["status"] == "active"
+
+
+async def test_unarchive_not_found(client: AsyncClient, auth_headers: dict):
+    response = await client.patch(
+        f"/api/v1/menu-items/{uuid.uuid4()}/unarchive", headers=auth_headers
     )
     assert response.status_code == 404

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -120,8 +120,8 @@ async def test_classify_progress_callback():
 
 async def test_correlate_matches_upcs():
     menu_items = [
-        {"id": "mi-1", "name": "Chicken Curry", "ingredients": "chicken, onion, spices"},
-        {"id": "mi-2", "name": "Salad", "ingredients": "cucumber, tomato"},
+        {"id": "mi-1", "name": "Chicken Curry", "body": "chicken, onion, spices"},
+        {"id": "mi-2", "name": "Salad", "body": "cucumber, tomato"},
     ]
     grocery_items = [
         {"upc": "AAA", "description": "Chicken Breast"},
@@ -145,7 +145,7 @@ async def test_correlate_matches_upcs():
 
 
 async def test_correlate_filters_invalid_upcs():
-    menu_items = [{"id": "mi-1", "name": "Test", "ingredients": "stuff"}]
+    menu_items = [{"id": "mi-1", "name": "Test", "body": "stuff"}]
     grocery_items = [{"upc": "AAA", "description": "Real Item"}]
 
     mock_generate = AsyncMock(return_value={"matched_upcs": ["AAA", "FAKE-UPC"]})
@@ -157,7 +157,7 @@ async def test_correlate_filters_invalid_upcs():
 
 
 async def test_correlate_no_matches():
-    menu_items = [{"id": "mi-1", "name": "Exotic", "ingredients": "truffle, saffron"}]
+    menu_items = [{"id": "mi-1", "name": "Exotic", "body": "truffle, saffron"}]
     grocery_items = [{"upc": "AAA", "description": "Onion"}]
 
     mock_generate = AsyncMock(return_value={"matched_upcs": []})


### PR DESCRIPTION
## Summary

Phase 1 of the backend changes required by the UI requirements (see `PHASES.md`):

- **Migration**: adds `body` column, backfills from `recipe || '\n\n' || ingredients`, drops old columns
- **Model & schemas**: single `body: str` replaces `recipe` + `ingredients`
- **Removes `created_by`/`updated_by` from `MenuItemResponse`** — creator info is implicit since users only see their own items
- **Removes fork endpoint** (`POST /menu-items/{id}/fork`) — forking was removed from requirements
- **Adds unarchive endpoint** (`PATCH /menu-items/{id}/unarchive`) — sets status back to `"active"`
- **Updates correlate service**: LLM prompt now sends the full `body` field instead of just `ingredients`
- **Updates order pipeline snapshot** to store `body` instead of `ingredients`
- **Updates all tests**: removes fork tests, adds unarchive tests, all 95 unit tests pass
- Adds `REQUIREMENTS.md` (full UI/UX requirements) and `PHASES.md` (implementation tracking)

## Test plan

- [x] All 95 unit tests pass (`uv run pytest --ignore=tests/test_integration.py -v`)
- [x] Ruff lint + format clean
- [ ] Run migration on dev DB (`CARTWISE_ENV=development uv run alembic upgrade head`)
- [ ] Integration tests with Ollama (requires docker + ollama running)