### PR TITLE
feat: add onboarding endpoint, splitwise_user_id, hardcode INR

### DIFF
--- a/backend/alembic/versions/e37c2a1db4ce_add_splitwise_user_id_to_users.py
+++ b/backend/alembic/versions/e37c2a1db4ce_add_splitwise_user_id_to_users.py
@@ -1,0 +1,26 @@
+"""add splitwise_user_id to users
+
+Revision ID: e37c2a1db4ce
+Revises: 5d59acc1cbe5
+Create Date: 2026-04-12
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e37c2a1db4ce"
+down_revision: str | None = "5d59acc1cbe5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("splitwise_user_id", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "splitwise_user_id")

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -1,7 +1,8 @@
 """
 Auth dependencies for FastAPI route protection.
 
-Validates Supabase JWT, finds or creates the user in our database.
+Validates Supabase JWT and looks up the user in our database.
+Users must complete onboarding (POST /auth/onboard) before they exist in the DB.
 """
 
 from typing import Annotated
@@ -22,7 +23,11 @@ async def get_current_user(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> User:
-    """Validate Supabase JWT and find-or-create user in our DB."""
+    """Validate Supabase JWT and find user in our DB.
+
+    Returns 401 if the token is invalid.
+    Returns 404 if the user hasn't completed onboarding yet.
+    """
     supabase_user = decode_supabase_jwt(credentials.credentials)
     if supabase_user is None:
         raise HTTPException(
@@ -30,22 +35,14 @@ async def get_current_user(
             detail="Invalid or expired token",
         )
 
-    # Find user by oauth_id (Supabase Auth UUID)
     result = await session.execute(select(User).where(User.oauth_id == supabase_user.auth_id))
     user = result.scalar_one_or_none()
 
     if user is None:
-        # First login — create user from Supabase JWT claims
-        user = User(
-            email=supabase_user.email,
-            name=supabase_user.name,
-            avatar_url=supabase_user.avatar_url,
-            oauth_provider=supabase_user.provider,
-            oauth_id=supabase_user.auth_id,
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found — complete onboarding first",
         )
-        session.add(user)
-        await session.commit()
-        await session.refresh(user)
 
     if not user.is_active:
         raise HTTPException(

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, String, func
+from sqlalchemy import DateTime, Integer, String, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -20,6 +20,7 @@ class User(Base):
     avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     oauth_provider: Mapped[str] = mapped_column(String(50))
     oauth_id: Mapped[str] = mapped_column(String(255))
+    splitwise_user_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     is_active: Mapped[bool] = mapped_column(default=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -9,25 +9,66 @@ for testing without a frontend.
 """
 
 import uuid
+from typing import Annotated
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel
 from sqlalchemy import select
 
-from app.auth.dependencies import CurrentUser
-from app.auth.jwt import create_test_token
+from app.auth.dependencies import CurrentUser, security
+from app.auth.jwt import create_test_token, decode_supabase_jwt
 from app.config import settings
 from app.database import SessionDep
 from app.models.user import User
-from app.schemas.user import UserResponse
+from app.schemas.user import OnboardRequest, UserResponse
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 @router.get("/me", response_model=UserResponse)
 async def get_me(current_user: CurrentUser):
-    """Get the current authenticated user."""
+    """Get the current authenticated user.
+
+    Returns 404 if the user hasn't completed onboarding yet.
+    """
     return current_user
+
+
+@router.post("/onboard", response_model=UserResponse, status_code=201)
+async def onboard(
+    data: OnboardRequest,
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+    session: SessionDep,
+):
+    """Complete onboarding — creates the user record in the DB.
+
+    Requires a valid Supabase JWT. The user must NOT already exist.
+    OAuth claims (email, avatar, provider) come from the JWT.
+    Name, phone, and splitwise_user_id come from the request body.
+    """
+    supabase_user = decode_supabase_jwt(credentials.credentials)
+    if supabase_user is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    # Check user doesn't already exist
+    result = await session.execute(select(User).where(User.oauth_id == supabase_user.auth_id))
+    if result.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="User already onboarded")
+
+    user = User(
+        email=supabase_user.email,
+        name=data.name,
+        phone=data.phone,
+        avatar_url=supabase_user.avatar_url,
+        oauth_provider=supabase_user.provider,
+        oauth_id=supabase_user.auth_id,
+        splitwise_user_id=data.splitwise_user_id,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
 
 
 # --- Dev-only endpoints (DEBUG=true) ---

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -13,6 +13,7 @@ class UserResponse(BaseModel):
     phone: str | None
     avatar_url: str | None
     oauth_provider: str
+    splitwise_user_id: int | None
     is_active: bool
     created_at: datetime
     updated_at: datetime
@@ -22,3 +23,9 @@ class UserUpdate(BaseModel):
     name: str | None = None
     phone: str | None = None
     avatar_url: str | None = None
+
+
+class OnboardRequest(BaseModel):
+    name: str
+    phone: str
+    splitwise_user_id: int

--- a/backend/app/services/splitwise.py
+++ b/backend/app/services/splitwise.py
@@ -55,7 +55,6 @@ def _build_expense_payload(
     cost: float,
     payer_sw_id: int,
     member_sw_ids: list[int],
-    currency_code: str = "INR",
     group_id: int = 0,
     details: str | None = None,
 ) -> dict:
@@ -71,7 +70,7 @@ def _build_expense_payload(
     payload = {
         "cost": f"{cost:.2f}",
         "description": description,
-        "currency_code": currency_code,
+        "currency_code": "INR",
         "group_id": group_id,
     }
 
@@ -120,7 +119,6 @@ async def create_expense_audited(
     payer_sw_id: int,
     member_sw_ids: list[int],
     order_id: uuid.UUID | None = None,
-    currency_code: str = "INR",
     group_id: int = 0,
     details: str | None = None,
 ) -> SplitwiseAuditLog:
@@ -135,7 +133,6 @@ async def create_expense_audited(
         cost=cost,
         payer_sw_id=payer_sw_id,
         member_sw_ids=member_sw_ids,
-        currency_code=currency_code,
         group_id=group_id,
         details=details,
     )
@@ -246,7 +243,6 @@ async def push_splits_audited(
     split_result: dict,
     member_id_to_sw_id: dict[str, int],
     payer_sw_id: int,
-    currency_code: str = "INR",
     group_id: int = 0,
 ) -> list[SplitwiseAuditLog]:
     """Push all split groups to Splitwise with per-expense auditing.
@@ -257,7 +253,6 @@ async def push_splits_audited(
         split_result: Output of compute_splits().
         member_id_to_sw_id: Map of our member ID → Splitwise user ID.
         payer_sw_id: Splitwise user ID of the payer.
-        currency_code: Currency (default INR).
         group_id: Splitwise group ID (0 for non-group).
 
     Returns:
@@ -291,7 +286,6 @@ async def push_splits_audited(
             payer_sw_id=payer_sw_id,
             member_sw_ids=sw_ids,
             order_id=order_id,
-            currency_code=currency_code,
             group_id=group_id,
             details=details,
         )

--- a/backend/tests/test_onboard.py
+++ b/backend/tests/test_onboard.py
@@ -1,0 +1,91 @@
+"""Unit tests for auth endpoints: /auth/me, /auth/onboard."""
+
+from httpx import AsyncClient
+
+from app.auth.jwt import create_test_token
+
+
+async def test_auth_me_returns_user(client: AsyncClient, auth_headers: dict, test_user):
+    """GET /auth/me returns the authenticated user."""
+    response = await client.get("/api/v1/auth/me", headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json()["email"] == test_user.email
+    assert response.json()["name"] == test_user.name
+
+
+async def test_auth_me_no_token(client: AsyncClient):
+    """GET /auth/me without token returns 401/403."""
+    response = await client.get("/api/v1/auth/me")
+    assert response.status_code in (401, 403)
+
+
+async def test_auth_me_before_onboard(client: AsyncClient):
+    """GET /auth/me with valid JWT but no user in DB returns 404."""
+    token = create_test_token("not-onboarded-oauth-id", "new@test.com")
+    response = await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 404
+
+
+async def test_onboard_creates_user(client: AsyncClient):
+    """POST /auth/onboard creates a new user."""
+    token = create_test_token("fresh-oauth-id", "fresh@test.com")
+    response = await client.post(
+        "/api/v1/auth/onboard",
+        json={"name": "Fresh User", "phone": "9876543210", "splitwise_user_id": 12345},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Fresh User"
+    assert data["phone"] == "9876543210"
+    assert data["splitwise_user_id"] == 12345
+    assert data["email"] == "fresh@test.com"
+
+
+async def test_onboard_then_auth_me(client: AsyncClient):
+    """After onboarding, GET /auth/me works."""
+    token = create_test_token("onboard-then-me", "onboard@test.com")
+
+    # Before onboard: 404
+    resp1 = await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp1.status_code == 404
+
+    # Onboard
+    await client.post(
+        "/api/v1/auth/onboard",
+        json={"name": "Onboarded", "phone": "1234567890", "splitwise_user_id": 99},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # After onboard: 200
+    resp2 = await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp2.status_code == 200
+    assert resp2.json()["name"] == "Onboarded"
+
+
+async def test_onboard_duplicate(client: AsyncClient):
+    """Onboarding twice with the same JWT returns 409."""
+    token = create_test_token("dup-oauth-id", "dup@test.com")
+
+    resp1 = await client.post(
+        "/api/v1/auth/onboard",
+        json={"name": "First", "phone": "1111111111", "splitwise_user_id": 1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp1.status_code == 201
+
+    resp2 = await client.post(
+        "/api/v1/auth/onboard",
+        json={"name": "Second", "phone": "2222222222", "splitwise_user_id": 2},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp2.status_code == 409
+
+
+async def test_onboard_no_token(client: AsyncClient):
+    """POST /auth/onboard without token returns 401/403."""
+    response = await client.post(
+        "/api/v1/auth/onboard",
+        json={"name": "No Token", "phone": "0000000000", "splitwise_user_id": 1},
+    )
+    assert response.status_code in (401, 403)

--- a/backend/tests/test_splitwise.py
+++ b/backend/tests/test_splitwise.py
@@ -40,7 +40,6 @@ def test_build_expense_payload_two_members():
         cost=100.0,
         payer_sw_id=1,
         member_sw_ids=[1, 2],
-        currency_code="INR",
     )
 
     assert payload["cost"] == "100.00"


### PR DESCRIPTION
## Summary

Phase 3 of backend changes (see `PHASES.md`):

- **Migration**: adds `splitwise_user_id` integer column to `users` (nullable for existing rows)
- **New `POST /auth/onboard`**: creates user record with `name`, `phone`, `splitwise_user_id` from request body + email/avatar/provider from Supabase JWT. Returns 409 if already onboarded.
- **`GET /auth/me` no longer auto-creates users**: returns 404 if user hasn't completed onboarding. Frontend uses this to decide: 404 → show onboarding form, 200 → go to home.
- **Hardcoded INR**: removed `currency_code` parameter from all Splitwise functions, hardcoded `"INR"` in payload.
- **Schema**: new `OnboardRequest`, `splitwise_user_id` added to `UserResponse`

## Test plan

- [x] All 106 unit tests pass
- [x] 7 new onboard tests: create user, duplicate (409), auth/me before onboard (404), full flow (onboard then auth/me), no token (401/403)
- [x] Ruff lint + format clean
- [x] Migration run on dev DB
- [ ] Integration tests (requires docker + ollama)