### PR TITLE
fix(ui): avoid disruptive 401 redirect during Supabase token refresh

### DIFF
--- a/ui/app/providers.tsx
+++ b/ui/app/providers.tsx
@@ -23,8 +23,10 @@ function getQueryClient() {
   if (isServer) {
     return makeQueryClient();
   } else {
-    if (!browserQueryClient) browserQueryClient = makeQueryClient();
-    registerApiQueryClient(browserQueryClient);
+    if (!browserQueryClient) {
+      browserQueryClient = makeQueryClient();
+      registerApiQueryClient(browserQueryClient);
+    }
     return browserQueryClient;
   }
 }

--- a/ui/app/providers.tsx
+++ b/ui/app/providers.tsx
@@ -5,6 +5,7 @@ import {
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query";
+import { registerApiQueryClient } from "@/lib/api/client";
 
 function makeQueryClient() {
   return new QueryClient({
@@ -23,6 +24,7 @@ function getQueryClient() {
     return makeQueryClient();
   } else {
     if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    registerApiQueryClient(browserQueryClient);
     return browserQueryClient;
   }
 }

--- a/ui/lib/api/client.ts
+++ b/ui/lib/api/client.ts
@@ -1,4 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query";
+import type { Session } from "@supabase/supabase-js";
 import createFetchClient, { type Middleware } from "openapi-fetch";
 import { createClient } from "@/lib/supabase/client";
 import type { paths } from "./schema";
@@ -14,6 +15,19 @@ export function registerApiQueryClient(client: QueryClient | null) {
 
 let sessionRecoveryPromise: Promise<boolean> | null = null;
 
+/** Matches GoTrueClient: refresh ~3 ticks before expiry at 30s per tick. */
+const SESSION_EXPIRY_MARGIN_MS = 90_000;
+
+function sessionHasUsableAccessToken(session: Session | null): session is Session {
+  if (!session?.access_token) {
+    return false;
+  }
+  if (session.expires_at == null) {
+    return false;
+  }
+  return session.expires_at * 1000 - Date.now() >= SESSION_EXPIRY_MARGIN_MS;
+}
+
 async function tryRecoverSessionAfter401(): Promise<boolean> {
   if (typeof window === "undefined") {
     return false;
@@ -28,7 +42,7 @@ async function tryRecoverSessionAfter401(): Promise<boolean> {
       const {
         data: { session },
       } = await supabase.auth.getSession();
-      if (session?.access_token) {
+      if (sessionHasUsableAccessToken(session)) {
         setAuthToken(session.access_token);
         return true;
       }

--- a/ui/lib/api/client.ts
+++ b/ui/lib/api/client.ts
@@ -28,7 +28,17 @@ function sessionHasUsableAccessToken(session: Session | null): session is Sessio
   return session.expires_at * 1000 - Date.now() >= SESSION_EXPIRY_MARGIN_MS;
 }
 
-async function tryRecoverSessionAfter401(): Promise<boolean> {
+function bearerFromRequest(request: Request): string | null {
+  const auth = request.headers.get("Authorization");
+  if (!auth?.toLowerCase().startsWith("bearer ")) {
+    return null;
+  }
+  return auth.slice(7).trim();
+}
+
+async function tryRecoverSessionAfter401(
+  failedAccessToken: string | null,
+): Promise<boolean> {
   if (typeof window === "undefined") {
     return false;
   }
@@ -42,7 +52,11 @@ async function tryRecoverSessionAfter401(): Promise<boolean> {
       const {
         data: { session },
       } = await supabase.auth.getSession();
-      if (sessionHasUsableAccessToken(session)) {
+      if (
+        sessionHasUsableAccessToken(session) &&
+        failedAccessToken != null &&
+        session.access_token !== failedAccessToken
+      ) {
         setAuthToken(session.access_token);
         return true;
       }
@@ -80,11 +94,12 @@ const authMiddleware: Middleware = {
     }
     return request;
   },
-  async onResponse({ response }) {
+  async onResponse({ response, request }) {
     if (response.status !== 401 || typeof window === "undefined") {
       return response;
     }
-    const recovered = await tryRecoverSessionAfter401();
+    const failedAccessToken = bearerFromRequest(request) ?? cachedToken;
+    const recovered = await tryRecoverSessionAfter401(failedAccessToken);
     if (recovered) {
       void browserQueryClient?.invalidateQueries();
       return response;

--- a/ui/lib/api/client.ts
+++ b/ui/lib/api/client.ts
@@ -1,7 +1,52 @@
+import type { QueryClient } from "@tanstack/react-query";
 import createFetchClient, { type Middleware } from "openapi-fetch";
+import { createClient } from "@/lib/supabase/client";
 import type { paths } from "./schema";
 
 let cachedToken: string | null = null;
+
+let browserQueryClient: QueryClient | null = null;
+
+/** Called from the React Query provider so 401 recovery can refresh stale queries. */
+export function registerApiQueryClient(client: QueryClient | null) {
+  browserQueryClient = client;
+}
+
+let sessionRecoveryPromise: Promise<boolean> | null = null;
+
+async function tryRecoverSessionAfter401(): Promise<boolean> {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  if (sessionRecoveryPromise) {
+    return sessionRecoveryPromise;
+  }
+
+  sessionRecoveryPromise = (async () => {
+    try {
+      const supabase = createClient();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (session?.access_token) {
+        setAuthToken(session.access_token);
+        return true;
+      }
+      const { data, error } = await supabase.auth.refreshSession();
+      if (error || !data.session?.access_token) {
+        return false;
+      }
+      setAuthToken(data.session.access_token);
+      return true;
+    } catch {
+      return false;
+    }
+  })().finally(() => {
+    sessionRecoveryPromise = null;
+  });
+
+  return sessionRecoveryPromise;
+}
 
 /**
  * Set the auth token for API calls. Called by the auth context
@@ -22,10 +67,16 @@ const authMiddleware: Middleware = {
     return request;
   },
   async onResponse({ response }) {
-    if (response.status === 401 && typeof window !== "undefined") {
-      cachedToken = null;
-      window.location.href = "/login";
+    if (response.status !== 401 || typeof window === "undefined") {
+      return response;
     }
+    const recovered = await tryRecoverSessionAfter401();
+    if (recovered) {
+      void browserQueryClient?.invalidateQueries();
+      return response;
+    }
+    setAuthToken(null);
+    window.location.href = "/login";
     return response;
   },
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The API client's `onResponse` middleware redirected to `/login` on every 401. With React Query's default `refetchOnWindowFocus`, returning to the PWA could fire requests with a stale in-memory token while Supabase was still refreshing the session, causing an unnecessary full-page redirect.

## Solution

- On 401 in the browser, attempt session recovery via `supabase.auth.getSession()` (only when `expires_at` indicates the access token is still within GoTrue's ~90s refresh margin **and** the session token differs from the JWT that just 401'd) then `refreshSession()` before treating the user as signed out. This avoids treating recovery as successful when `getSession()` returns the same rejected token (revocation, JWT rotation, etc.).
- Deduplicate concurrent recovery attempts so parallel 401s share one refresh.
- After a successful recovery, invalidate all React Query queries so refetches use the updated `cachedToken` (registered from the existing `QueryClientProvider`).

## Files

- `ui/lib/api/client.ts` — recovery + redirect only when recovery fails
- `ui/app/providers.tsx` — register browser `QueryClient` for post-recovery invalidation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef10cbb0-6bb9-41c0-b7ec-4c19b50dc7cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef10cbb0-6bb9-41c0-b7ec-4c19b50dc7cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

