### PR TITLE
fix(ui): meal plan reorder with @dnd-kit/sortable (touch + keyboard)

### DIFF
--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -84,28 +84,46 @@ export default function MealPlanEditPage() {
     setMode("reorder");
   }
 
-  // Bug fix: use ref for dragIndex to avoid stale closure in rapid drag events
-  function handleDragStart(index: number) {
-    dragIndexRef.current = index;
-    setDraggingIndex(index);
+  function readReorderIndexFromPoint(
+    clientX: number,
+    clientY: number,
+  ): number | null {
+    const el = document.elementFromPoint(clientX, clientY);
+    const row = el?.closest("[data-meal-reorder-index]");
+    if (!row || !(row instanceof HTMLElement)) return null;
+    const raw = row.getAttribute("data-meal-reorder-index");
+    if (raw === null) return null;
+    const n = Number.parseInt(raw, 10);
+    return Number.isNaN(n) ? null : n;
   }
 
-  function handleDragOver(e: React.DragEvent, index: number) {
-    e.preventDefault();
-    const fromIndex = dragIndexRef.current;
-    if (fromIndex === null || fromIndex === index) return;
+  function applyReorder(fromIndex: number, toIndex: number) {
+    if (fromIndex === toIndex) return;
     setOrderedItems((prev) => {
       if (!prev) return prev;
       const next = [...prev];
       const [moved] = next.splice(fromIndex, 1);
-      next.splice(index, 0, moved);
+      next.splice(toIndex, 0, moved);
       return next;
     });
+    dragIndexRef.current = toIndex;
+    setDraggingIndex(toIndex);
+  }
+
+  function handleReorderPointerDown(index: number) {
     dragIndexRef.current = index;
     setDraggingIndex(index);
   }
 
-  function handleDragEnd() {
+  function handleReorderPointerMove(e: React.PointerEvent) {
+    const fromIndex = dragIndexRef.current;
+    if (fromIndex === null) return;
+    const toIndex = readReorderIndexFromPoint(e.clientX, e.clientY);
+    if (toIndex === null || toIndex === fromIndex) return;
+    applyReorder(fromIndex, toIndex);
+  }
+
+  function handleReorderPointerEnd() {
     dragIndexRef.current = null;
     setDraggingIndex(null);
   }
@@ -179,18 +197,18 @@ export default function MealPlanEditPage() {
             )}
           </>
         ) : (
-          // TODO: Replace HTML5 drag-and-drop with @dnd-kit/sortable for mobile/touch support.
-          // HTML5 DnD does not fire on mobile browsers.
           <ul>
             {orderedItems?.map((item, index) => (
               <MealPlanItem
                 key={item.id}
                 name={item.name}
                 mode="reorder"
+                reorderIndex={index}
                 dragging={draggingIndex === index}
-                onDragStart={() => handleDragStart(index)}
-                onDragOver={(e) => handleDragOver(e, index)}
-                onDragEnd={handleDragEnd}
+                onReorderPointerDown={() => handleReorderPointerDown(index)}
+                onReorderPointerMove={handleReorderPointerMove}
+                onReorderPointerUp={handleReorderPointerEnd}
+                onReorderPointerCancel={handleReorderPointerEnd}
               />
             ))}
           </ul>

--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -1,8 +1,25 @@
 "use client";
 
-import { useState, useMemo, useRef } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { useAuth } from "@/lib/auth";
 import { $api } from "@/lib/api/hooks";
 import apiClient from "@/lib/api/client";
@@ -12,6 +29,38 @@ import { Icon } from "@/components/icon";
 
 type Mode = "select" | "reorder";
 
+type OrderedRow = { id: string; name: string };
+
+function SortableMealPlanRow({ item }: { item: OrderedRow }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <MealPlanItem
+      ref={setNodeRef}
+      name={item.name}
+      mode="reorder"
+      sortableRowStyle={style}
+      sortableAttributes={attributes}
+      sortableListeners={listeners}
+      setSortableActivatorRef={setActivatorNodeRef}
+      dragging={isDragging}
+    />
+  );
+}
+
 export default function MealPlanEditPage() {
   const { appUser } = useAuth();
   const router = useRouter();
@@ -20,8 +69,15 @@ export default function MealPlanEditPage() {
   const [search, setSearch] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
-  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
-  const dragIndexRef = useRef<number | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
 
   const { data: menuItems, isLoading: menuItemsLoading } = $api.useQuery(
     "get",
@@ -43,9 +99,7 @@ export default function MealPlanEditPage() {
   const [selected, setSelected] = useState<Set<string> | null>(null);
   const current = selected ?? initialIds;
 
-  const [orderedItems, setOrderedItems] = useState<
-    { id: string; name: string }[] | null
-  >(null);
+  const [orderedItems, setOrderedItems] = useState<OrderedRow[] | null>(null);
 
   const filtered = useMemo(() => {
     if (!menuItems) return [];
@@ -84,48 +138,16 @@ export default function MealPlanEditPage() {
     setMode("reorder");
   }
 
-  function readReorderIndexFromPoint(
-    clientX: number,
-    clientY: number,
-  ): number | null {
-    const el = document.elementFromPoint(clientX, clientY);
-    const row = el?.closest("[data-meal-reorder-index]");
-    if (!row || !(row instanceof HTMLElement)) return null;
-    const raw = row.getAttribute("data-meal-reorder-index");
-    if (raw === null) return null;
-    const n = Number.parseInt(raw, 10);
-    return Number.isNaN(n) ? null : n;
-  }
-
-  function applyReorder(fromIndex: number, toIndex: number) {
-    if (fromIndex === toIndex) return;
-    setOrderedItems((prev) => {
-      if (!prev) return prev;
-      const next = [...prev];
-      const [moved] = next.splice(fromIndex, 1);
-      next.splice(toIndex, 0, moved);
-      return next;
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setOrderedItems((items) => {
+      if (!items) return items;
+      const oldIndex = items.findIndex((i) => i.id === active.id);
+      const newIndex = items.findIndex((i) => i.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return items;
+      return arrayMove(items, oldIndex, newIndex);
     });
-    dragIndexRef.current = toIndex;
-    setDraggingIndex(toIndex);
-  }
-
-  function handleReorderPointerDown(index: number) {
-    dragIndexRef.current = index;
-    setDraggingIndex(index);
-  }
-
-  function handleReorderPointerMove(e: React.PointerEvent) {
-    const fromIndex = dragIndexRef.current;
-    if (fromIndex === null) return;
-    const toIndex = readReorderIndexFromPoint(e.clientX, e.clientY);
-    if (toIndex === null || toIndex === fromIndex) return;
-    applyReorder(fromIndex, toIndex);
-  }
-
-  function handleReorderPointerEnd() {
-    dragIndexRef.current = null;
-    setDraggingIndex(null);
   }
 
   // Bug fix: handle API errors, reset saving state on failure
@@ -148,9 +170,13 @@ export default function MealPlanEditPage() {
       return;
     }
 
-    await queryClient.invalidateQueries({ queryKey: ["get", "/api/v1/meal-plans/{user_id}"] });
+    await queryClient.invalidateQueries({
+      queryKey: ["get", "/api/v1/meal-plans/{user_id}"],
+    });
     router.replace("/meal-plan");
   }
+
+  const sortableIds = orderedItems?.map((i) => i.id) ?? [];
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -197,21 +223,24 @@ export default function MealPlanEditPage() {
             )}
           </>
         ) : (
-          <ul>
-            {orderedItems?.map((item, index) => (
-              <MealPlanItem
-                key={item.id}
-                name={item.name}
-                mode="reorder"
-                reorderIndex={index}
-                dragging={draggingIndex === index}
-                onReorderPointerDown={() => handleReorderPointerDown(index)}
-                onReorderPointerMove={handleReorderPointerMove}
-                onReorderPointerUp={handleReorderPointerEnd}
-                onReorderPointerCancel={handleReorderPointerEnd}
-              />
-            ))}
-          </ul>
+          orderedItems && (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={sortableIds}
+                strategy={verticalListSortingStrategy}
+              >
+                <ul>
+                  {orderedItems.map((item) => (
+                    <SortableMealPlanRow key={item.id} item={item} />
+                  ))}
+                </ul>
+              </SortableContext>
+            </DndContext>
+          )
         )}
       </main>
 

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -1,11 +1,13 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "ui",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@serwist/next": "^9.5.7",
         "@supabase/auth-ui-react": "^0.4.7",
         "@supabase/auth-ui-shared": "^0.1.8",
@@ -107,6 +109,14 @@
     "@base-ui/react": ["@base-ui/react@1.3.0", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@base-ui/utils": "0.2.6", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "tabbable": "^6.4.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA=="],
 
     "@base-ui/utils": ["@base-ui/utils@0.2.6", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.61.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-utL3cpZoFzflyqUkjYbxYujI6STBTmO5LFn4bbin/NZnRWN6wQ7eErhr3/Vpa5h/jicPFC6kTa42r940mQftJQ=="],
 

--- a/ui/components/meal-plan-item.tsx
+++ b/ui/components/meal-plan-item.tsx
@@ -16,6 +16,7 @@ interface MealPlanItemProps {
   onTap?: () => void;
   /** Applied to the root `<li>` in reorder mode (transform / transition from @dnd-kit). */
   sortableRowStyle?: CSSProperties;
+  /** Draggable a11y props from `useSortable`; must live on the same node as `sortableListeners` when using a handle. */
   sortableAttributes?: DraggableAttributes;
   sortableListeners?: DraggableSyntheticListeners;
   setSortableActivatorRef?: (element: HTMLButtonElement | null) => void;
@@ -45,7 +46,6 @@ export const MealPlanItem = forwardRef<HTMLLIElement, MealPlanItemProps>(
         className={`flex items-center gap-4 border-b border-gray-200 py-5 ${
           dragging ? "opacity-50" : ""
         }`}
-        {...(mode === "reorder" ? (sortableAttributes ?? {}) : {})}
       >
         <div className="flex w-6 shrink-0 justify-center">
           {mode === "view" && <span className="text-sm">-</span>}
@@ -63,6 +63,7 @@ export const MealPlanItem = forwardRef<HTMLLIElement, MealPlanItemProps>(
               ref={setSortableActivatorRef}
               aria-label="Drag to reorder"
               className="flex touch-none cursor-grab appearance-none items-center justify-center border-0 bg-transparent p-0 active:cursor-grabbing"
+              {...(sortableAttributes ?? {})}
               {...(sortableListeners ?? {})}
             >
               <Icon

--- a/ui/components/meal-plan-item.tsx
+++ b/ui/components/meal-plan-item.tsx
@@ -1,3 +1,9 @@
+import { forwardRef } from "react";
+import type { CSSProperties } from "react";
+import type {
+  DraggableAttributes,
+  DraggableSyntheticListeners,
+} from "@dnd-kit/core";
 import { Icon } from "@/components/icon";
 
 type Mode = "view" | "select" | "reorder";
@@ -8,93 +14,81 @@ interface MealPlanItemProps {
   checked?: boolean;
   onToggle?: () => void;
   onTap?: () => void;
-  /** Row index for reorder mode; sets `data-meal-reorder-index` on the row. */
-  reorderIndex?: number;
-  onReorderPointerDown?: (e: React.PointerEvent<HTMLButtonElement>) => void;
-  onReorderPointerMove?: (e: React.PointerEvent<HTMLButtonElement>) => void;
-  onReorderPointerUp?: (e: React.PointerEvent<HTMLButtonElement>) => void;
-  onReorderPointerCancel?: (e: React.PointerEvent<HTMLButtonElement>) => void;
+  /** Applied to the root `<li>` in reorder mode (transform / transition from @dnd-kit). */
+  sortableRowStyle?: CSSProperties;
+  sortableAttributes?: DraggableAttributes;
+  sortableListeners?: DraggableSyntheticListeners;
+  setSortableActivatorRef?: (element: HTMLButtonElement | null) => void;
   dragging?: boolean;
 }
 
-export function MealPlanItem({
-  name,
-  mode,
-  checked,
-  onToggle,
-  onTap,
-  reorderIndex,
-  onReorderPointerDown,
-  onReorderPointerMove,
-  onReorderPointerUp,
-  onReorderPointerCancel,
-  dragging,
-}: MealPlanItemProps) {
-  return (
-    <li
-      data-meal-reorder-index={
-        mode === "reorder" && reorderIndex !== undefined
-          ? reorderIndex
-          : undefined
-      }
-      className={`flex items-center gap-4 border-b border-gray-200 py-5 ${
-        dragging ? "opacity-50" : ""
-      }`}
-    >
-      <div className="w-6 shrink-0 flex justify-center">
-        {mode === "view" && <span className="text-sm">-</span>}
-        {mode === "select" && (
-          <input
-            type="checkbox"
-            checked={checked}
-            onChange={onToggle}
-            className="h-5 w-5 appearance-none border-2 border-neutral-400 checked:border-neutral-800 checked:bg-neutral-800"
-          />
-        )}
-        {mode === "reorder" && (
-          <button
-            type="button"
-            aria-label="Drag to reorder"
-            className="flex cursor-grab touch-none appearance-none items-center justify-center border-0 bg-transparent p-0 active:cursor-grabbing"
-            onPointerDown={(e) => {
-              e.preventDefault();
-              e.currentTarget.setPointerCapture(e.pointerId);
-              onReorderPointerDown?.(e);
-            }}
-            onPointerMove={(e) => {
-              if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
-              onReorderPointerMove?.(e);
-            }}
-            onPointerUp={(e) => {
-              if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-                e.currentTarget.releasePointerCapture(e.pointerId);
-              }
-              onReorderPointerUp?.(e);
-            }}
-            onPointerCancel={(e) => {
-              if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-                e.currentTarget.releasePointerCapture(e.pointerId);
-              }
-              onReorderPointerCancel?.(e);
-            }}
-          >
-            <Icon name="drag_indicator" size={20} className="text-neutral-400" />
-          </button>
-        )}
-      </div>
+export const MealPlanItem = forwardRef<HTMLLIElement, MealPlanItemProps>(
+  function MealPlanItem(
+    {
+      name,
+      mode,
+      checked,
+      onToggle,
+      onTap,
+      sortableRowStyle,
+      sortableAttributes,
+      sortableListeners,
+      setSortableActivatorRef,
+      dragging,
+    },
+    ref,
+  ) {
+    return (
+      <li
+        ref={ref}
+        style={mode === "reorder" ? sortableRowStyle : undefined}
+        className={`flex items-center gap-4 border-b border-gray-200 py-5 ${
+          dragging ? "opacity-50" : ""
+        }`}
+        {...(mode === "reorder" ? (sortableAttributes ?? {}) : {})}
+      >
+        <div className="flex w-6 shrink-0 justify-center">
+          {mode === "view" && <span className="text-sm">-</span>}
+          {mode === "select" && (
+            <input
+              type="checkbox"
+              checked={checked}
+              onChange={onToggle}
+              className="h-5 w-5 appearance-none border-2 border-neutral-400 checked:border-neutral-800 checked:bg-neutral-800"
+            />
+          )}
+          {mode === "reorder" && (
+            <button
+              type="button"
+              ref={setSortableActivatorRef}
+              aria-label="Drag to reorder"
+              className="flex touch-none cursor-grab appearance-none items-center justify-center border-0 bg-transparent p-0 active:cursor-grabbing"
+              {...(sortableListeners ?? {})}
+            >
+              <Icon
+                name="drag_indicator"
+                size={20}
+                className="text-neutral-400"
+              />
+            </button>
+          )}
+        </div>
 
-      {onTap ? (
-        <button
-          onClick={onTap}
-          className="flex-1 text-left text-sm font-medium tracking-item"
-        >
-          {name}
-        </button>
-      ) : (
-        <span className="flex-1 text-sm font-medium tracking-item">
-          {name}
-        </span>
-      )}
-    </li>
-  );
-}
+        {onTap ? (
+          <button
+            onClick={onTap}
+            className="flex-1 text-left text-sm font-medium tracking-item"
+          >
+            {name}
+          </button>
+        ) : (
+          <span className="flex-1 text-sm font-medium tracking-item">
+            {name}
+          </span>
+        )}
+      </li>
+    );
+  },
+);
+
+MealPlanItem.displayName = "MealPlanItem";

--- a/ui/components/meal-plan-item.tsx
+++ b/ui/components/meal-plan-item.tsx
@@ -8,9 +8,12 @@ interface MealPlanItemProps {
   checked?: boolean;
   onToggle?: () => void;
   onTap?: () => void;
-  onDragStart?: () => void;
-  onDragOver?: (e: React.DragEvent) => void;
-  onDragEnd?: () => void;
+  /** Row index for reorder mode; sets `data-meal-reorder-index` on the row. */
+  reorderIndex?: number;
+  onReorderPointerDown?: (e: React.PointerEvent<HTMLButtonElement>) => void;
+  onReorderPointerMove?: (e: React.PointerEvent<HTMLButtonElement>) => void;
+  onReorderPointerUp?: (e: React.PointerEvent<HTMLButtonElement>) => void;
+  onReorderPointerCancel?: (e: React.PointerEvent<HTMLButtonElement>) => void;
   dragging?: boolean;
 }
 
@@ -20,20 +23,23 @@ export function MealPlanItem({
   checked,
   onToggle,
   onTap,
-  onDragStart,
-  onDragOver,
-  onDragEnd,
+  reorderIndex,
+  onReorderPointerDown,
+  onReorderPointerMove,
+  onReorderPointerUp,
+  onReorderPointerCancel,
   dragging,
 }: MealPlanItemProps) {
   return (
     <li
-      draggable={mode === "reorder"}
-      onDragStart={onDragStart}
-      onDragOver={onDragOver}
-      onDragEnd={onDragEnd}
+      data-meal-reorder-index={
+        mode === "reorder" && reorderIndex !== undefined
+          ? reorderIndex
+          : undefined
+      }
       className={`flex items-center gap-4 border-b border-gray-200 py-5 ${
-        mode === "reorder" ? "cursor-grab active:cursor-grabbing" : ""
-      } ${dragging ? "opacity-50" : ""}`}
+        dragging ? "opacity-50" : ""
+      }`}
     >
       <div className="w-6 shrink-0 flex justify-center">
         {mode === "view" && <span className="text-sm">-</span>}
@@ -46,7 +52,34 @@ export function MealPlanItem({
           />
         )}
         {mode === "reorder" && (
-          <Icon name="drag_indicator" size={20} className="text-neutral-400" />
+          <button
+            type="button"
+            aria-label="Drag to reorder"
+            className="flex cursor-grab touch-none appearance-none items-center justify-center border-0 bg-transparent p-0 active:cursor-grabbing"
+            onPointerDown={(e) => {
+              e.preventDefault();
+              e.currentTarget.setPointerCapture(e.pointerId);
+              onReorderPointerDown?.(e);
+            }}
+            onPointerMove={(e) => {
+              if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
+              onReorderPointerMove?.(e);
+            }}
+            onPointerUp={(e) => {
+              if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+                e.currentTarget.releasePointerCapture(e.pointerId);
+              }
+              onReorderPointerUp?.(e);
+            }}
+            onPointerCancel={(e) => {
+              if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+                e.currentTarget.releasePointerCapture(e.pointerId);
+              }
+              onReorderPointerCancel?.(e);
+            }}
+          >
+            <Icon name="drag_indicator" size={20} className="text-neutral-400" />
+          </button>
         )}
       </div>
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@serwist/next": "^9.5.7",
     "@supabase/auth-ui-react": "^0.4.7",
     "@supabase/auth-ui-shared": "^0.1.8",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Meal plan reorder on the edit screen uses **`@dnd-kit/core`** and **`@dnd-kit/sortable`**.

## Review follow-up

- **Sortable handle:** `attributes` and `listeners` from `useSortable` are both applied to the drag **handle** `<button>`, not the `<li>`, so list semantics stay correct and keyboard instructions match the focused control (per dnd-kit).

## Dependencies

- `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`; `ui/bun.lock` updated.

## Verification

- `npx tsc --noEmit` and `npm run lint` in `ui/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c53aa03-4fa7-4a4a-94f7-42784924a9dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c53aa03-4fa7-4a4a-94f7-42784924a9dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

