### PR TITLE
feat: Splitwise OAuth 2.0 per-user token connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ wheels/
 .claude/skills/
 .agents/
 skills-lock.json
+.mcp.json
 
 # Node (root — husky + lint-staged deps)
 node_modules/

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_splitwise_connected_at_to_users.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_splitwise_connected_at_to_users.py
@@ -1,0 +1,29 @@
+"""add splitwise_connected_at to users
+
+Revision ID: a1b2c3d4e5f6
+Revises: 048ccd693969
+Create Date: 2026-04-30
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "048ccd693969"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("splitwise_connected_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "splitwise_connected_at")

--- a/backend/alembic/versions/b2c3d4e5f6a7_drop_phone_from_users.py
+++ b/backend/alembic/versions/b2c3d4e5f6a7_drop_phone_from_users.py
@@ -1,0 +1,29 @@
+"""drop phone from users
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-30
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("users", "phone")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("phone", sa.String(length=50), nullable=True),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,7 +23,7 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# Middleware (order matters — outermost first)
+# Middleware (order matters — last added runs first)
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -16,11 +16,13 @@ class User(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     name: Mapped[str] = mapped_column(String(255))
-    phone: Mapped[str | None] = mapped_column(String(50), nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     oauth_provider: Mapped[str] = mapped_column(String(50))
     oauth_id: Mapped[str] = mapped_column(String(255))
     splitwise_user_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    splitwise_connected_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     is_active: Mapped[bool] = mapped_column(default=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
@@ -32,3 +34,7 @@ class User(Base):
         back_populates="creator", foreign_keys="MenuItem.created_by"
     )
     meal_plan: Mapped[MealPlan | None] = relationship(back_populates="user")
+
+    @property
+    def splitwise_connected(self) -> bool:
+        return self.splitwise_connected_at is not None

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -98,7 +98,12 @@ class SplitwiseExchangeRequest(BaseModel):
     redirect_uri: str
 
 
-@router.post("/splitwise/connect")
+class SplitwiseConnectResponse(BaseModel):
+    authorize_url: str
+    redirect_uri: str
+
+
+@router.post("/splitwise/connect", response_model=SplitwiseConnectResponse)
 async def splitwise_connect(current_user: CurrentUser):
     """Start the Splitwise OAuth flow.
 

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -4,11 +4,18 @@ Auth routes.
 OAuth login is handled by Supabase Auth on the frontend.
 The backend only validates Supabase JWTs and returns user info.
 
+Splitwise OAuth 2.0 connection is handled here — users connect their
+Splitwise account during onboarding so expenses are created from their account.
+
 In development (DEBUG=true), a dev-login endpoint is available
 for testing without a frontend.
 """
 
+import hashlib
+import hmac
+import secrets
 import uuid
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -21,7 +28,33 @@ from app.auth.jwt import create_test_token, decode_supabase_jwt
 from app.config import settings
 from app.database import SessionDep
 from app.models.user import User
-from app.schemas.user import OnboardRequest, UserResponse
+from app.schemas.user import UserResponse
+from app.services.vault import store_secret
+
+
+def _sign_state(user_id: str, nonce: str) -> str:
+    """Encode user_id + nonce into a signed OAuth state parameter."""
+    payload = f"{user_id}:{nonce}"
+    sig = hmac.new(
+        settings.SESSION_SECRET_KEY.encode(), payload.encode(), hashlib.sha256
+    ).hexdigest()[:16]
+    return f"{sig}.{payload}"
+
+
+def _verify_state(state: str) -> str | None:
+    """Verify and extract user_id from signed state. Returns None if invalid."""
+    try:
+        sig, payload = state.split(".", 1)
+        expected = hmac.new(
+            settings.SESSION_SECRET_KEY.encode(), payload.encode(), hashlib.sha256
+        ).hexdigest()[:16]
+        if not hmac.compare_digest(sig, expected):
+            return None
+        user_id, _ = payload.split(":", 1)
+        return user_id
+    except ValueError, AttributeError:
+        return None
+
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -37,38 +70,126 @@ async def get_me(current_user: CurrentUser):
 
 @router.post("/onboard", response_model=UserResponse, status_code=201)
 async def onboard(
-    data: OnboardRequest,
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
     session: SessionDep,
 ):
     """Complete onboarding — creates the user record in the DB.
 
     Requires a valid Supabase JWT. The user must NOT already exist.
-    OAuth claims (email, avatar, provider) come from the JWT.
-    Name, phone, and splitwise_user_id come from the request body.
+    All user fields (email, name, avatar, provider) come from JWT claims.
     """
     supabase_user = decode_supabase_jwt(credentials.credentials)
     if supabase_user is None:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
 
-    # Check user doesn't already exist
     result = await session.execute(select(User).where(User.oauth_id == supabase_user.auth_id))
     if result.scalar_one_or_none() is not None:
         raise HTTPException(status_code=409, detail="User already onboarded")
 
     user = User(
         email=supabase_user.email,
-        name=data.name,
-        phone=data.phone,
+        name=supabase_user.name or supabase_user.email.split("@")[0],
         avatar_url=supabase_user.avatar_url,
         oauth_provider=supabase_user.provider,
         oauth_id=supabase_user.auth_id,
-        splitwise_user_id=data.splitwise_user_id,
     )
     session.add(user)
     await session.commit()
     await session.refresh(user)
     return user
+
+
+# --- Splitwise OAuth 2.0 ---
+
+
+class SplitwiseExchangeRequest(BaseModel):
+    code: str
+    state: str
+    redirect_uri: str
+
+
+@router.post("/splitwise/connect")
+async def splitwise_connect(current_user: CurrentUser):
+    """Start the Splitwise OAuth flow.
+
+    Returns an authorize_url the frontend navigates to, plus the redirect_uri
+    that the frontend callback route must echo back during token exchange.
+    """
+    from authlib.integrations.httpx_client import AsyncOAuth2Client
+
+    state = _sign_state(str(current_user.id), secrets.token_urlsafe(16))
+    redirect_uri = f"{settings.FRONTEND_URL}/auth/connect/splitwise"
+
+    async with AsyncOAuth2Client(
+        client_id=settings.SPLITWISE_CONSUMER_KEY,
+        client_secret=settings.SPLITWISE_CONSUMER_SECRET,
+    ) as client:
+        uri, _ = client.create_authorization_url(
+            f"{settings.SPLITWISE_OAUTH_BASE_URL}/oauth/authorize",
+            redirect_uri=redirect_uri,
+            state=state,
+        )
+
+    return {"authorize_url": uri, "redirect_uri": redirect_uri}
+
+
+@router.post("/splitwise/exchange")
+async def splitwise_exchange(body: SplitwiseExchangeRequest, session: SessionDep):
+    """Exchange a Splitwise authorization code for an access token.
+
+    Called by the frontend callback route after Splitwise redirects back.
+    The frontend forwards code + state + redirect_uri; backend handles
+    token exchange, stores the token in Vault, and returns success/failure.
+    """
+    from authlib.integrations.httpx_client import AsyncOAuth2Client
+
+    user_id = _verify_state(body.state)
+    if not user_id:
+        raise HTTPException(status_code=400, detail="Invalid state")
+
+    try:
+        async with AsyncOAuth2Client(
+            client_id=settings.SPLITWISE_CONSUMER_KEY,
+            client_secret=settings.SPLITWISE_CONSUMER_SECRET,
+            token_endpoint_auth_method="client_secret_post",
+        ) as client:
+            token = await client.fetch_token(
+                f"{settings.SPLITWISE_OAUTH_BASE_URL}/oauth/token",
+                code=body.code,
+                redirect_uri=body.redirect_uri,
+            )
+
+            access_token = token.get("access_token")
+            if not access_token:
+                raise HTTPException(status_code=502, detail="No access token received")
+
+            resp = await client.get(
+                f"{settings.SPLITWISE_BASE_URL}/get_current_user",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            if resp.status_code != 200:
+                raise HTTPException(status_code=502, detail="Failed to fetch Splitwise user")
+
+            sw_user = resp.json()["user"]
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail="Splitwise OAuth exchange failed") from exc
+
+    await store_secret(
+        session,
+        f"splitwise_token:{user_id}",
+        access_token,
+        f"Splitwise token for user {user_id}",
+    )
+
+    user = await session.get(User, uuid.UUID(user_id))
+    user.splitwise_user_id = sw_user["id"]
+    user.splitwise_connected_at = datetime.now(UTC)
+    await session.commit()
+
+    return {"success": True}
 
 
 # --- Dev-only endpoints (DEBUG=true) ---

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -11,8 +11,6 @@ In development (DEBUG=true), a dev-login endpoint is available
 for testing without a frontend.
 """
 
-import hashlib
-import hmac
 import secrets
 import uuid
 from datetime import UTC, datetime
@@ -20,6 +18,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
+from itsdangerous import BadSignature, URLSafeTimedSerializer
 from pydantic import BaseModel
 from sqlalchemy import select
 
@@ -31,28 +30,19 @@ from app.models.user import User
 from app.schemas.user import UserResponse
 from app.services.vault import store_secret
 
+_signer = URLSafeTimedSerializer(settings.SESSION_SECRET_KEY)
+STATE_MAX_AGE = 600  # 10 minutes
+
 
 def _sign_state(user_id: str, nonce: str) -> str:
-    """Encode user_id + nonce into a signed OAuth state parameter."""
-    payload = f"{user_id}:{nonce}"
-    sig = hmac.new(
-        settings.SESSION_SECRET_KEY.encode(), payload.encode(), hashlib.sha256
-    ).hexdigest()[:16]
-    return f"{sig}.{payload}"
+    return _signer.dumps({"uid": user_id, "nonce": nonce})
 
 
-def _verify_state(state: str) -> str | None:
-    """Verify and extract user_id from signed state. Returns None if invalid."""
+def _verify_state(state: str, max_age: int = STATE_MAX_AGE) -> str | None:
     try:
-        sig, payload = state.split(".", 1)
-        expected = hmac.new(
-            settings.SESSION_SECRET_KEY.encode(), payload.encode(), hashlib.sha256
-        ).hexdigest()[:16]
-        if not hmac.compare_digest(sig, expected):
-            return None
-        user_id, _ = payload.split(":", 1)
-        return user_id
-    except ValueError, AttributeError:
+        data = _signer.loads(state, max_age=max_age)
+        return data["uid"]
+    except BadSignature, KeyError, TypeError:
         return None
 
 

--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -343,6 +343,9 @@ async def approve_order(
     }
 
     from app.services.splitwise import push_splits_audited
+    from app.services.vault import get_secret
+
+    payer_token = await get_secret(session, f"splitwise_token:{order.paid_by}")
 
     audits = await push_splits_audited(
         session=session,
@@ -350,6 +353,7 @@ async def approve_order(
         split_result=split_result,
         member_id_to_sw_id=member_id_to_sw_id,
         payer_sw_id=payer_sw_id,
+        token=payer_token,
     )
 
     # Update split statuses from audit results

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -28,4 +28,4 @@ class UserUpdate(BaseModel):
 class OnboardRequest(BaseModel):
     name: str
     phone: str
-    splitwise_user_id: int
+    splitwise_user_id: int | None = None

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -10,10 +10,10 @@ class UserResponse(BaseModel):
     id: uuid.UUID
     email: str
     name: str
-    phone: str | None
     avatar_url: str | None
     oauth_provider: str
     splitwise_user_id: int | None
+    splitwise_connected: bool
     is_active: bool
     created_at: datetime
     updated_at: datetime
@@ -21,11 +21,4 @@ class UserResponse(BaseModel):
 
 class UserUpdate(BaseModel):
     name: str | None = None
-    phone: str | None = None
     avatar_url: str | None = None
-
-
-class OnboardRequest(BaseModel):
-    name: str
-    phone: str
-    splitwise_user_id: int | None = None

--- a/backend/app/services/splitwise.py
+++ b/backend/app/services/splitwise.py
@@ -40,8 +40,11 @@ def _check_enabled() -> None:
         )
 
 
-def _headers() -> dict:
-    return {"Authorization": f"Bearer {settings.SPLITWISE_API_KEY}"}
+def _headers(token: str | None = None) -> dict:
+    auth_token = token or settings.get("SPLITWISE_API_KEY", "")
+    if not auth_token:
+        raise SplitwiseDisabledError("No Splitwise token available.")
+    return {"Authorization": f"Bearer {auth_token}"}
 
 
 def _payload_hash(payload: dict) -> str:
@@ -121,6 +124,7 @@ async def create_expense_audited(
     order_id: uuid.UUID | None = None,
     group_id: int = 0,
     details: str | None = None,
+    token: str | None = None,
 ) -> SplitwiseAuditLog:
     """Create an expense in Splitwise with full audit trail.
 
@@ -164,7 +168,7 @@ async def create_expense_audited(
 
     # Step 2: Call Splitwise API
     try:
-        resp = httpx.post(f"{_base_url()}/create_expense", headers=_headers(), json=payload)
+        resp = httpx.post(f"{_base_url()}/create_expense", headers=_headers(token), json=payload)
         resp.raise_for_status()
         data = resp.json()
 
@@ -192,6 +196,7 @@ async def delete_expense_audited(
     session: AsyncSession,
     splitwise_expense_id: int,
     order_id: uuid.UUID | None = None,
+    token: str | None = None,
 ) -> SplitwiseAuditLog:
     """Delete an expense from Splitwise with audit trail."""
     _check_enabled()
@@ -211,7 +216,7 @@ async def delete_expense_audited(
 
     try:
         resp = httpx.post(
-            f"{_base_url()}/delete_expense/{splitwise_expense_id}", headers=_headers()
+            f"{_base_url()}/delete_expense/{splitwise_expense_id}", headers=_headers(token)
         )
         resp.raise_for_status()
         data = resp.json()
@@ -244,6 +249,7 @@ async def push_splits_audited(
     member_id_to_sw_id: dict[str, int],
     payer_sw_id: int,
     group_id: int = 0,
+    token: str | None = None,
 ) -> list[SplitwiseAuditLog]:
     """Push all split groups to Splitwise with per-expense auditing.
 
@@ -288,6 +294,7 @@ async def push_splits_audited(
             order_id=order_id,
             group_id=group_id,
             details=details,
+            token=token,
         )
         audits.append(audit)
 
@@ -300,6 +307,7 @@ async def push_splits_audited(
 async def rollback_order_expenses(
     session: AsyncSession,
     order_id: uuid.UUID,
+    token: str | None = None,
 ) -> list[SplitwiseAuditLog]:
     """Delete all successfully created Splitwise expenses for an order.
 
@@ -323,6 +331,7 @@ async def rollback_order_expenses(
             session=session,
             splitwise_expense_id=audit_row.splitwise_expense_id,
             order_id=order_id,
+            token=token,
         )
         delete_audits.append(delete_audit)
 

--- a/backend/app/services/vault.py
+++ b/backend/app/services/vault.py
@@ -1,0 +1,48 @@
+"""
+Supabase Vault service for secure secret storage.
+
+Uses the Postgres vault extension (pgsodium) for server-managed encryption.
+Secrets are encrypted at rest and only decrypted on-the-fly via the
+vault.decrypted_secrets view.
+
+For local dev without Vault, falls back to a plaintext secrets table.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def store_secret(
+    session: AsyncSession, name: str, secret: str, description: str = ""
+) -> None:
+    existing = await session.execute(
+        text("SELECT id FROM vault.secrets WHERE name = :name"),
+        {"name": name},
+    )
+    if existing.scalar_one_or_none():
+        await session.execute(
+            text("UPDATE vault.secrets SET secret = :secret WHERE name = :name"),
+            {"name": name, "secret": secret},
+        )
+    else:
+        await session.execute(
+            text("SELECT vault.create_secret(:secret, :name, :description)"),
+            {"secret": secret, "name": name, "description": description},
+        )
+
+
+async def get_secret(session: AsyncSession, name: str) -> str | None:
+    result = await session.execute(
+        text("SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = :name"),
+        {"name": name},
+    )
+    return result.scalar_one_or_none()
+
+
+async def delete_secret(session: AsyncSession, name: str) -> None:
+    await session.execute(
+        text("DELETE FROM vault.secrets WHERE name = :name"),
+        {"name": name},
+    )

--- a/backend/mock/splitwise.py
+++ b/backend/mock/splitwise.py
@@ -12,9 +12,11 @@ For persistent verification, check the splitwise_audit_log table in the real DB.
 """
 
 import itertools
+import uuid
 from datetime import UTC, datetime
 
 from fastapi import FastAPI, Request
+from starlette.responses import RedirectResponse
 
 app = FastAPI(title="Mock Splitwise", version="0.1.0")
 
@@ -202,3 +204,22 @@ async def reset_ledger():
     """Debug endpoint: clear all expenses."""
     _expenses.clear()
     return {"success": True, "message": "Ledger cleared"}
+
+
+# --- OAuth 2.0 mock endpoints ---
+
+
+@app.get("/oauth/authorize")
+async def mock_authorize(response_type: str, client_id: str, redirect_uri: str, state: str):
+    """Mock OAuth authorize — immediately redirects back with a code."""
+    code = f"mock_code_{uuid.uuid4().hex[:8]}"
+    return RedirectResponse(f"{redirect_uri}?code={code}&state={state}")
+
+
+@app.post("/oauth/token")
+async def mock_token():
+    """Mock token exchange — returns a fake access token."""
+    return {
+        "access_token": f"mock_token_{uuid.uuid4().hex[:8]}",
+        "token_type": "bearer",
+    }

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "structlog==25.5.0",
     "supabase==2.15.1",
     "uvicorn[standard]==0.44.0",
+    "authlib>=1.3.0",
+    "itsdangerous>=2.2.0",
 ]
 
 [dependency-groups]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "dynaconf==3.2.13",
     "fastapi==0.135.3",
     "httpx==0.28.1",
-    "litellm==1.83.4",
+    "litellm>=1.83.7",
     "pdfplumber==0.11.9",
     "pyjwt==2.12.1",
     "python-multipart==0.0.26",
@@ -20,6 +20,7 @@ dependencies = [
     "uvicorn[standard]==0.44.0",
     "authlib>=1.3.0",
     "itsdangerous>=2.2.0",
+    "python-dotenv>=1.2.2",
 ]
 
 [dependency-groups]

--- a/backend/settings.toml
+++ b/backend/settings.toml
@@ -19,11 +19,19 @@ DATABASE_URL = ""
 
 # Splitwise — actual values in .secrets.toml (gitignored)
 # SPLITWISE_ENABLED must be explicitly true to allow API calls
+# Default points to mock server — only production overrides to real Splitwise
 SPLITWISE_ENABLED = false
-SPLITWISE_BASE_URL = "https://secure.splitwise.com/api/v3.0"
+SPLITWISE_BASE_URL = "http://localhost:8001/api/mock/splitwise/v3.0"
+SPLITWISE_OAUTH_BASE_URL = "http://localhost:8001"
 SPLITWISE_API_KEY = ""
 SPLITWISE_CONSUMER_KEY = ""
 SPLITWISE_CONSUMER_SECRET = ""
+
+# Frontend URL (for OAuth callback redirects)
+FRONTEND_URL = "http://localhost:3000"
+
+# Session/signing secret — set in .secrets.toml
+SESSION_SECRET_KEY = ""
 
 # Mock server (for local mock services)
 MOCK_SERVER_PORT = 8001
@@ -31,11 +39,16 @@ MOCK_SERVER_PORT = 8001
 [development]
 DEBUG = true
 SPLITWISE_ENABLED = true
-SPLITWISE_BASE_URL = "http://localhost:8001/api/mock/splitwise/v3.0"
+CORS_ORIGINS = ["http://lr602lw45l.taile1dca.ts.net:3000", "http://localhost:3000"]
+FRONTEND_URL = "http://lr602lw45l.taile1dca.ts.net:3000"
+SESSION_SECRET_KEY = "dev-session-secret-not-for-production"
 
 [testing]
 DEBUG = true
 SPLITWISE_ENABLED = true
-SPLITWISE_BASE_URL = "http://localhost:8001/api/mock/splitwise/v3.0"
+SESSION_SECRET_KEY = "test-session-secret"
 
 [production]
+# Real Splitwise — only production hits the actual API
+SPLITWISE_BASE_URL = "https://secure.splitwise.com/api/v3.0"
+SPLITWISE_OAUTH_BASE_URL = "https://secure.splitwise.com"

--- a/backend/tests/test_auth_splitwise.py
+++ b/backend/tests/test_auth_splitwise.py
@@ -25,24 +25,22 @@ class TestSignedState:
         assert _verify_state(s1) == user_id
         assert _verify_state(s2) == user_id
 
-    def test_tampered_signature_rejected(self):
+    def test_tampered_state_rejected(self):
         state = _sign_state("user-id", "nonce")
-        tampered = "0000000000000000" + state[16:]
-        assert _verify_state(tampered) is None
-
-    def test_tampered_payload_rejected(self):
-        state = _sign_state("user-id", "nonce")
-        sig, _ = state.split(".", 1)
-        tampered = f"{sig}.attacker-id:nonce"
+        tampered = state[:-4] + "XXXX"
         assert _verify_state(tampered) is None
 
     def test_garbage_input_returns_none(self):
         assert _verify_state("") is None
-        assert _verify_state("no-dot-here") is None
-        assert _verify_state("a.b") is None  # no colon in payload
+        assert _verify_state("not-a-valid-token") is None
+        assert _verify_state("a.b.c") is None
 
     def test_none_input_returns_none(self):
         assert _verify_state(None) is None  # type: ignore[arg-type]
+
+    def test_expired_state_rejected(self):
+        state = _sign_state("user-id", "nonce")
+        assert _verify_state(state, max_age=-1) is None
 
 
 class TestSplitwiseConnect:

--- a/backend/tests/test_auth_splitwise.py
+++ b/backend/tests/test_auth_splitwise.py
@@ -1,0 +1,180 @@
+"""Tests for Splitwise OAuth flow and signed state helpers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import AsyncClient
+
+from app.routes.auth import _sign_state, _verify_state
+
+AUTHLIB_PATH = "authlib.integrations.httpx_client.AsyncOAuth2Client"
+
+
+class TestSignedState:
+    """Unit tests for _sign_state / _verify_state helpers."""
+
+    def test_roundtrip(self):
+        user_id = "2376dc61-0e27-47e9-a117-d7a283515794"
+        state = _sign_state(user_id, "random-nonce")
+        assert _verify_state(state) == user_id
+
+    def test_different_nonces_produce_different_states(self):
+        user_id = "abc-123"
+        s1 = _sign_state(user_id, "nonce1")
+        s2 = _sign_state(user_id, "nonce2")
+        assert s1 != s2
+        assert _verify_state(s1) == user_id
+        assert _verify_state(s2) == user_id
+
+    def test_tampered_signature_rejected(self):
+        state = _sign_state("user-id", "nonce")
+        tampered = "0000000000000000" + state[16:]
+        assert _verify_state(tampered) is None
+
+    def test_tampered_payload_rejected(self):
+        state = _sign_state("user-id", "nonce")
+        sig, _ = state.split(".", 1)
+        tampered = f"{sig}.attacker-id:nonce"
+        assert _verify_state(tampered) is None
+
+    def test_garbage_input_returns_none(self):
+        assert _verify_state("") is None
+        assert _verify_state("no-dot-here") is None
+        assert _verify_state("a.b") is None  # no colon in payload
+
+    def test_none_input_returns_none(self):
+        assert _verify_state(None) is None  # type: ignore[arg-type]
+
+
+class TestSplitwiseConnect:
+    """Integration tests for POST /auth/splitwise/connect."""
+
+    async def test_returns_authorize_url_and_redirect_uri(
+        self, client: AsyncClient, auth_headers: dict, test_user
+    ):
+        response = await client.post("/api/v1/auth/splitwise/connect", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert "authorize_url" in data
+        assert "redirect_uri" in data
+        assert "/oauth/authorize" in data["authorize_url"]
+        assert "state=" in data["authorize_url"]
+        assert data["redirect_uri"].endswith("/auth/connect/splitwise")
+
+    async def test_state_contains_user_id(self, client: AsyncClient, auth_headers: dict, test_user):
+        response = await client.post("/api/v1/auth/splitwise/connect", headers=auth_headers)
+        url = response.json()["authorize_url"]
+        from urllib.parse import parse_qs, urlparse
+
+        parsed = urlparse(url)
+        state = parse_qs(parsed.query)["state"][0]
+        assert _verify_state(state) == str(test_user.id)
+
+    async def test_redirect_uri_in_authorize_url_matches_response(
+        self, client: AsyncClient, auth_headers: dict, test_user
+    ):
+        response = await client.post("/api/v1/auth/splitwise/connect", headers=auth_headers)
+        data = response.json()
+        from urllib.parse import parse_qs, urlparse
+
+        parsed = urlparse(data["authorize_url"])
+        url_redirect_uri = parse_qs(parsed.query)["redirect_uri"][0]
+        assert url_redirect_uri == data["redirect_uri"]
+
+    async def test_requires_auth(self, client: AsyncClient):
+        response = await client.post("/api/v1/auth/splitwise/connect")
+        assert response.status_code in (401, 403)
+
+
+class TestSplitwiseExchange:
+    """Integration tests for POST /auth/splitwise/exchange."""
+
+    async def test_invalid_state_returns_400(self, client: AsyncClient):
+        response = await client.post(
+            "/api/v1/auth/splitwise/exchange",
+            json={"code": "fake", "state": "garbage", "redirect_uri": "http://x/cb"},
+        )
+        assert response.status_code == 400
+        assert "Invalid state" in response.json()["detail"]
+
+    async def test_successful_exchange(self, client: AsyncClient, test_user, session):
+        state = _sign_state(str(test_user.id), "test-nonce")
+
+        mock_token_resp = {"access_token": "mock_token_abc", "token_type": "bearer"}
+        mock_user_resp = {"user": {"id": 12345, "first_name": "Test", "last_name": "SW"}}
+
+        instance = AsyncMock()
+        instance.fetch_token = AsyncMock(return_value=mock_token_resp)
+        mock_get_resp = MagicMock()
+        mock_get_resp.status_code = 200
+        mock_get_resp.json.return_value = mock_user_resp
+        instance.get = AsyncMock(return_value=mock_get_resp)
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=instance)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(AUTHLIB_PATH, return_value=mock_ctx),
+            patch("app.routes.auth.store_secret", new_callable=AsyncMock) as mock_vault,
+        ):
+            response = await client.post(
+                "/api/v1/auth/splitwise/exchange",
+                json={
+                    "code": "real-code",
+                    "state": state,
+                    "redirect_uri": "http://localhost:3000/auth/splitwise/callback",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True}
+        mock_vault.assert_called_once_with(
+            session,
+            f"splitwise_token:{test_user.id}",
+            "mock_token_abc",
+            f"Splitwise token for user {test_user.id}",
+        )
+
+    async def test_token_exchange_failure_returns_502(self, client: AsyncClient, test_user):
+        state = _sign_state(str(test_user.id), "test-nonce")
+
+        instance = AsyncMock()
+        instance.fetch_token = AsyncMock(side_effect=Exception("network error"))
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=instance)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(AUTHLIB_PATH, return_value=mock_ctx):
+            response = await client.post(
+                "/api/v1/auth/splitwise/exchange",
+                json={
+                    "code": "bad-code",
+                    "state": state,
+                    "redirect_uri": "http://localhost:3000/auth/splitwise/callback",
+                },
+            )
+
+        assert response.status_code == 502
+
+    async def test_no_access_token_returns_502(self, client: AsyncClient, test_user):
+        state = _sign_state(str(test_user.id), "test-nonce")
+
+        instance = AsyncMock()
+        instance.fetch_token = AsyncMock(return_value={"error": "invalid_grant"})
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=instance)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(AUTHLIB_PATH, return_value=mock_ctx):
+            response = await client.post(
+                "/api/v1/auth/splitwise/exchange",
+                json={
+                    "code": "expired-code",
+                    "state": state,
+                    "redirect_uri": "http://localhost:3000/auth/splitwise/callback",
+                },
+            )
+
+        assert response.status_code == 502

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -188,12 +188,11 @@ async def test_update_own_profile(client: AsyncClient):
     token, user_id = await _login(client, "update@test.com", "Before")
     resp = await client.patch(
         f"/api/v1/users/{user_id}",
-        json={"name": "After", "phone": "+911234567890"},
+        json={"name": "After"},
         headers=_auth(token),
     )
     assert resp.status_code == 200
     assert resp.json()["name"] == "After"
-    assert resp.json()["phone"] == "+911234567890"
 
 
 async def test_update_other_user_forbidden(client: AsyncClient):

--- a/backend/tests/test_onboard.py
+++ b/backend/tests/test_onboard.py
@@ -27,40 +27,34 @@ async def test_auth_me_before_onboard(client: AsyncClient):
 
 
 async def test_onboard_creates_user(client: AsyncClient):
-    """POST /auth/onboard creates a new user."""
+    """POST /auth/onboard creates a new user from JWT claims."""
     token = create_test_token("fresh-oauth-id", "fresh@test.com")
     response = await client.post(
         "/api/v1/auth/onboard",
-        json={"name": "Fresh User", "phone": "9876543210", "splitwise_user_id": 12345},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 201
     data = response.json()
-    assert data["name"] == "Fresh User"
-    assert data["phone"] == "9876543210"
-    assert data["splitwise_user_id"] == 12345
     assert data["email"] == "fresh@test.com"
+    assert data["name"] == "Test User"
+    assert data["splitwise_connected"] is False
 
 
 async def test_onboard_then_auth_me(client: AsyncClient):
     """After onboarding, GET /auth/me works."""
     token = create_test_token("onboard-then-me", "onboard@test.com")
 
-    # Before onboard: 404
     resp1 = await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
     assert resp1.status_code == 404
 
-    # Onboard
     await client.post(
         "/api/v1/auth/onboard",
-        json={"name": "Onboarded", "phone": "1234567890", "splitwise_user_id": 99},
         headers={"Authorization": f"Bearer {token}"},
     )
 
-    # After onboard: 200
     resp2 = await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
     assert resp2.status_code == 200
-    assert resp2.json()["name"] == "Onboarded"
+    assert resp2.json()["name"] == "Test User"
 
 
 async def test_onboard_duplicate(client: AsyncClient):
@@ -69,14 +63,12 @@ async def test_onboard_duplicate(client: AsyncClient):
 
     resp1 = await client.post(
         "/api/v1/auth/onboard",
-        json={"name": "First", "phone": "1111111111", "splitwise_user_id": 1},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp1.status_code == 201
 
     resp2 = await client.post(
         "/api/v1/auth/onboard",
-        json={"name": "Second", "phone": "2222222222", "splitwise_user_id": 2},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp2.status_code == 409
@@ -84,8 +76,5 @@ async def test_onboard_duplicate(client: AsyncClient):
 
 async def test_onboard_no_token(client: AsyncClient):
     """POST /auth/onboard without token returns 401/403."""
-    response = await client.post(
-        "/api/v1/auth/onboard",
-        json={"name": "No Token", "phone": "0000000000", "splitwise_user_id": 1},
-    )
+    response = await client.post("/api/v1/auth/onboard")
     assert response.status_code in (401, 403)

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -34,12 +34,11 @@ async def test_get_user_not_found(client: AsyncClient):
 async def test_update_own_profile(client: AsyncClient, test_user: User, auth_headers: dict):
     response = await client.patch(
         f"/api/v1/users/{test_user.id}",
-        json={"name": "Updated Name", "phone": "+911234567890"},
+        json={"name": "Updated Name"},
         headers=auth_headers,
     )
     assert response.status_code == 200
     assert response.json()["name"] == "Updated Name"
-    assert response.json()["phone"] == "+911234567890"
 
 
 async def test_update_other_user_forbidden(

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -152,15 +152,30 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
+]
+
+[[package]]
 name = "backend"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
+    { name = "authlib" },
     { name = "dynaconf" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "itsdangerous" },
     { name = "litellm" },
     { name = "pdfplumber" },
     { name = "pyjwt" },
@@ -183,9 +198,11 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = "==1.18.4" },
     { name = "asyncpg", specifier = "==0.31.0" },
+    { name = "authlib", specifier = ">=1.3.0" },
     { name = "dynaconf", specifier = "==3.2.13" },
     { name = "fastapi", specifier = "==0.135.3" },
     { name = "httpx", specifier = "==0.28.1" },
+    { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "litellm", specifier = "==1.83.4" },
     { name = "pdfplumber", specifier = "==0.11.9" },
     { name = "pyjwt", specifier = "==2.12.1" },
@@ -728,6 +745,15 @@ wheels = [
 ]
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -772,6 +798,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
     { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
     { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
 ]
 
 [[package]]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.5"
+version = "3.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -24,42 +24,42 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/4a/064321452809dae953c1ed6e017504e72551a26b6f5708a5a80e4bf556ff/aiohttp-3.13.4.tar.gz", hash = "sha256:d97a6d09c66087890c2ab5d49069e1e570583f7ac0314ecf98294c1b6aaebd38", size = 7859748, upload-time = "2026-03-28T17:19:40.6Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload-time = "2026-03-31T21:58:50.229Z" },
-    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload-time = "2026-03-31T21:58:52.232Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload-time = "2026-03-31T21:58:54.566Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload-time = "2026-03-31T21:58:56.864Z" },
-    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload-time = "2026-03-31T21:58:59.072Z" },
-    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload-time = "2026-03-31T21:59:01.776Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload-time = "2026-03-31T21:59:04.568Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload-time = "2026-03-31T21:59:07.221Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload-time = "2026-03-31T21:59:09.484Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload-time = "2026-03-31T21:59:12.068Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload-time = "2026-03-31T21:59:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload-time = "2026-03-31T21:59:17.068Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload-time = "2026-03-31T21:59:19.541Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload-time = "2026-03-31T21:59:22.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload-time = "2026-03-31T21:59:24.635Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload-time = "2026-03-31T21:59:27.291Z" },
-    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload-time = "2026-03-31T21:59:29.429Z" },
-    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload-time = "2026-03-31T21:59:31.547Z" },
-    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload-time = "2026-03-31T21:59:34.098Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload-time = "2026-03-31T21:59:36.497Z" },
-    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload-time = "2026-03-31T21:59:38.723Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload-time = "2026-03-31T21:59:41.187Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload-time = "2026-03-31T21:59:43.84Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload-time = "2026-03-31T21:59:46.187Z" },
-    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload-time = "2026-03-31T21:59:48.656Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload-time = "2026-03-31T21:59:51.284Z" },
-    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload-time = "2026-03-31T21:59:53.753Z" },
-    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload-time = "2026-03-31T21:59:56.239Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload-time = "2026-03-31T21:59:59.103Z" },
-    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload-time = "2026-03-31T22:00:02.116Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload-time = "2026-03-31T22:00:04.756Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/29/6657cc37ae04cacc2dbf53fb730a06b6091cc4cbe745028e047c53e6d840/aiohttp-3.13.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:e0a2c961fc92abeff61d6444f2ce6ad35bb982db9fc8ff8a47455beacf454a57", size = 749363, upload-time = "2026-03-28T17:17:24.044Z" },
+    { url = "https://files.pythonhosted.org/packages/90/7f/30ccdf67ca3d24b610067dc63d64dcb91e5d88e27667811640644aa4a85d/aiohttp-3.13.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:153274535985a0ff2bff1fb6c104ed547cec898a09213d21b0f791a44b14d933", size = 499317, upload-time = "2026-03-28T17:17:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/93/13/e372dd4e68ad04ee25dafb050c7f98b0d91ea643f7352757e87231102555/aiohttp-3.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:351f3171e2458da3d731ce83f9e6b9619e325c45cbd534c7759750cabf453ad7", size = 500477, upload-time = "2026-03-28T17:17:28.279Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/fe/ee6298e8e586096fb6f5eddd31393d8544f33ae0792c71ecbb4c2bef98ac/aiohttp-3.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f989ac8bc5595ff761a5ccd32bdb0768a117f36dd1504b1c2c074ed5d3f4df9c", size = 1737227, upload-time = "2026-03-28T17:17:30.587Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b9/a7a0463a09e1a3fe35100f74324f23644bfc3383ac5fd5effe0722a5f0b7/aiohttp-3.13.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d36fc1709110ec1e87a229b201dd3ddc32aa01e98e7868083a794609b081c349", size = 1694036, upload-time = "2026-03-28T17:17:33.29Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7c/8972ae3fb7be00a91aee6b644b2a6a909aedb2c425269a3bfd90115e6f8f/aiohttp-3.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:42adaeea83cbdf069ab94f5103ce0787c21fb1a0153270da76b59d5578302329", size = 1786814, upload-time = "2026-03-28T17:17:36.035Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/c81e97e85c774decbaf0d577de7d848934e8166a3a14ad9f8aa5be329d28/aiohttp-3.13.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:92deb95469928cc41fd4b42a95d8012fa6df93f6b1c0a83af0ffbc4a5e218cde", size = 1866676, upload-time = "2026-03-28T17:17:38.441Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5f/5b46fe8694a639ddea2cd035bf5729e4677ea882cb251396637e2ef1590d/aiohttp-3.13.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c0c7c07c4257ef3a1df355f840bc62d133bcdef5c1c5ba75add3c08553e2eed", size = 1740842, upload-time = "2026-03-28T17:17:40.783Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a2/0d4b03d011cca6b6b0acba8433193c1e484efa8d705ea58295590fe24203/aiohttp-3.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f062c45de8a1098cb137a1898819796a2491aec4e637a06b03f149315dff4d8f", size = 1566508, upload-time = "2026-03-28T17:17:43.235Z" },
+    { url = "https://files.pythonhosted.org/packages/98/17/e689fd500da52488ec5f889effd6404dece6a59de301e380f3c64f167beb/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:76093107c531517001114f0ebdb4f46858ce818590363e3e99a4a2280334454a", size = 1700569, upload-time = "2026-03-28T17:17:46.165Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/0d/66402894dbcf470ef7db99449e436105ea862c24f7ea4c95c683e635af35/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:6f6ec32162d293b82f8b63a16edc80769662fbd5ae6fbd4936d3206a2c2cc63b", size = 1707407, upload-time = "2026-03-28T17:17:48.825Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/eb/af0ab1a3650092cbd8e14ef29e4ab0209e1460e1c299996c3f8288b3f1ff/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5903e2db3d202a00ad9f0ec35a122c005e85d90c9836ab4cda628f01edf425e2", size = 1752214, upload-time = "2026-03-28T17:17:51.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/bf/72326f8a98e4c666f292f03c385545963cc65e358835d2a7375037a97b57/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2d5bea57be7aca98dbbac8da046d99b5557c5cf4e28538c4c786313078aca09e", size = 1562162, upload-time = "2026-03-28T17:17:53.634Z" },
+    { url = "https://files.pythonhosted.org/packages/67/9f/13b72435f99151dd9a5469c96b3b5f86aa29b7e785ca7f35cf5e538f74c0/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:bcf0c9902085976edc0232b75006ef38f89686901249ce14226b6877f88464fb", size = 1768904, upload-time = "2026-03-28T17:17:55.991Z" },
+    { url = "https://files.pythonhosted.org/packages/18/bc/28d4970e7d5452ac7776cdb5431a1164a0d9cf8bd2fffd67b4fb463aa56d/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3295f98bfeed2e867cab588f2a146a9db37a85e3ae9062abf46ba062bd29165", size = 1723378, upload-time = "2026-03-28T17:17:58.348Z" },
+    { url = "https://files.pythonhosted.org/packages/53/74/b32458ca1a7f34d65bdee7aef2036adbe0438123d3d53e2b083c453c24dd/aiohttp-3.13.4-cp314-cp314-win32.whl", hash = "sha256:a598a5c5767e1369d8f5b08695cab1d8160040f796c4416af76fd773d229b3c9", size = 438711, upload-time = "2026-03-28T17:18:00.728Z" },
+    { url = "https://files.pythonhosted.org/packages/40/b2/54b487316c2df3e03a8f3435e9636f8a81a42a69d942164830d193beb56a/aiohttp-3.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:c555db4bc7a264bead5a7d63d92d41a1122fcd39cc62a4db815f45ad46f9c2c8", size = 464977, upload-time = "2026-03-28T17:18:03.367Z" },
+    { url = "https://files.pythonhosted.org/packages/47/fb/e41b63c6ce71b07a59243bb8f3b457ee0c3402a619acb9d2c0d21ef0e647/aiohttp-3.13.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:45abbbf09a129825d13c18c7d3182fecd46d9da3cfc383756145394013604ac1", size = 781549, upload-time = "2026-03-28T17:18:05.779Z" },
+    { url = "https://files.pythonhosted.org/packages/97/53/532b8d28df1e17e44c4d9a9368b78dcb6bf0b51037522136eced13afa9e8/aiohttp-3.13.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:74c80b2bc2c2adb7b3d1941b2b60701ee2af8296fc8aad8b8bc48bc25767266c", size = 514383, upload-time = "2026-03-28T17:18:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1f/62e5d400603e8468cd635812d99cb81cfdc08127a3dc474c647615f31339/aiohttp-3.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c97989ae40a9746650fa196894f317dafc12227c808c774929dda0ff873a5954", size = 518304, upload-time = "2026-03-28T17:18:10.642Z" },
+    { url = "https://files.pythonhosted.org/packages/90/57/2326b37b10896447e3c6e0cbef4fe2486d30913639a5cfd1332b5d870f82/aiohttp-3.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dae86be9811493f9990ef44fff1685f5c1a3192e9061a71a109d527944eed551", size = 1893433, upload-time = "2026-03-28T17:18:13.121Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b4/a24d82112c304afdb650167ef2fe190957d81cbddac7460bedd245f765aa/aiohttp-3.13.4-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1db491abe852ca2fa6cc48a3341985b0174b3741838e1341b82ac82c8bd9e871", size = 1755901, upload-time = "2026-03-28T17:18:16.21Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0883ef9d878d7846287f036c162a951968f22aabeef3ac97b0bea6f76d5d/aiohttp-3.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0e5d701c0aad02a7dce72eef6b93226cf3734330f1a31d69ebbf69f33b86666e", size = 1876093, upload-time = "2026-03-28T17:18:18.703Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/52/9204bb59c014869b71971addad6778f005daa72a96eed652c496789d7468/aiohttp-3.13.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8ac32a189081ae0a10ba18993f10f338ec94341f0d5df8fff348043962f3c6f8", size = 1970815, upload-time = "2026-03-28T17:18:21.858Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b5/e4eb20275a866dde0f570f411b36c6b48f7b53edfe4f4071aa1b0728098a/aiohttp-3.13.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98e968cdaba43e45c73c3f306fca418c8009a957733bac85937c9f9cf3f4de27", size = 1816223, upload-time = "2026-03-28T17:18:24.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/23/e98075c5bb146aa61a1239ee1ac7714c85e814838d6cebbe37d3fe19214a/aiohttp-3.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca114790c9144c335d538852612d3e43ea0f075288f4849cf4b05d6cd2238ce7", size = 1649145, upload-time = "2026-03-28T17:18:27.269Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c1/7bad8be33bb06c2bb224b6468874346026092762cbec388c3bdb65a368ee/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ea2e071661ba9cfe11eabbc81ac5376eaeb3061f6e72ec4cc86d7cdd1ffbdbbb", size = 1816562, upload-time = "2026-03-28T17:18:29.847Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/10/c00323348695e9a5e316825969c88463dcc24c7e9d443244b8a2c9cf2eae/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:34e89912b6c20e0fd80e07fa401fd218a410aa1ce9f1c2f1dad6db1bd0ce0927", size = 1800333, upload-time = "2026-03-28T17:18:32.269Z" },
+    { url = "https://files.pythonhosted.org/packages/84/43/9b2147a1df3559f49bd723e22905b46a46c068a53adb54abdca32c4de180/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0e217cf9f6a42908c52b46e42c568bd57adc39c9286ced31aaace614b6087965", size = 1820617, upload-time = "2026-03-28T17:18:35.238Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7f/b3481a81e7a586d02e99387b18c6dafff41285f6efd3daa2124c01f87eae/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:0c296f1221e21ba979f5ac1964c3b78cfde15c5c5f855ffd2caab337e9cd9182", size = 1643417, upload-time = "2026-03-28T17:18:37.949Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/72/07181226bc99ce1124e0f89280f5221a82d3ae6a6d9d1973ce429d48e52b/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d99a9d168ebaffb74f36d011750e490085ac418f4db926cce3989c8fe6cb6b1b", size = 1849286, upload-time = "2026-03-28T17:18:40.534Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/e6/1b3566e103eca6da5be4ae6713e112a053725c584e96574caf117568ffef/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cb19177205d93b881f3f89e6081593676043a6828f59c78c17a0fd6c1fbed2ba", size = 1782635, upload-time = "2026-03-28T17:18:43.073Z" },
+    { url = "https://files.pythonhosted.org/packages/37/58/1b11c71904b8d079eb0c39fe664180dd1e14bebe5608e235d8bfbadc8929/aiohttp-3.13.4-cp314-cp314t-win32.whl", hash = "sha256:c606aa5656dab6552e52ca368e43869c916338346bfaf6304e15c58fb113ea30", size = 472537, upload-time = "2026-03-28T17:18:46.286Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/8f/87c56a1a1977d7dddea5b31e12189665a140fdb48a71e9038ff90bb564ec/aiohttp-3.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:014dcc10ec8ab8db681f0d68e939d1e9286a5aa2b993cbbdb0db130853e02144", size = 506381, upload-time = "2026-03-28T17:18:48.74Z" },
 ]
 
 [[package]]
@@ -179,6 +179,7 @@ dependencies = [
     { name = "litellm" },
     { name = "pdfplumber" },
     { name = "pyjwt" },
+    { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
@@ -203,9 +204,10 @@ requires-dist = [
     { name = "fastapi", specifier = "==0.135.3" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
-    { name = "litellm", specifier = "==1.83.4" },
+    { name = "litellm", specifier = ">=1.83.7" },
     { name = "pdfplumber", specifier = "==0.11.9" },
     { name = "pyjwt", specifier = "==2.12.1" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = "==0.0.26" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = "==2.0.49" },
     { name = "structlog", specifier = "==25.5.0" },
@@ -841,7 +843,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.4"
+version = "1.83.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -857,9 +859,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/c4/30469c06ae7437a4406bc11e3c433cfd380a6771068cca15ea918dcd158f/litellm-1.83.4.tar.gz", hash = "sha256:6458d2030a41229460b321adee00517a91dbd8e63213cc953d355cb41d16f2d4", size = 17733899, upload-time = "2026-04-07T04:33:47.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/bd/df19d3f8f6654535ee343a341fd921f81c411abf601a53e3eaef58129b02/litellm-1.83.4-py3-none-any.whl", hash = "sha256:17d7b4d48d47aca988ea4f762ddda5e7bd72cda3270192b22813d0330869d7b4", size = 16015555, upload-time = "2026-04-07T04:33:44.268Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
 ]
 
 [[package]]
@@ -972,7 +974,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.30.0"
+version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -984,9 +986,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
 ]
 
 [[package]]
@@ -1286,11 +1288,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.0.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115, upload-time = "2024-01-23T06:33:00.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863, upload-time = "2024-01-23T06:32:58.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]

--- a/ui/app/(authenticated)/invoice/[id]/page.tsx
+++ b/ui/app/(authenticated)/invoice/[id]/page.tsx
@@ -184,7 +184,7 @@ export default function SplitAnalysisPage() {
 
   if (orderLoading) {
     return (
-      <div className="flex min-h-screen flex-col">
+      <div className="flex flex-1 flex-col">
         <TopBar showBack onBack={handleBack} />
         <div className="flex items-stretch justify-between border-b border-black">
           <span className="flex items-center p-3 text-2xl font-bold tracking-label uppercase leading-6">
@@ -198,7 +198,7 @@ export default function SplitAnalysisPage() {
   if (!order && !orderLoading) notFound();
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex flex-1 flex-col">
       <TopBar showBack onBack={handleBack} />
 
       {/* Status bar */}

--- a/ui/app/(authenticated)/invoice/[id]/result/page.tsx
+++ b/ui/app/(authenticated)/invoice/[id]/result/page.tsx
@@ -60,7 +60,7 @@ export default function SplitResultPage() {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen flex-col">
+      <div className="flex flex-1 flex-col">
         <TopBar showBack onBack={() => router.push("/meal-plan")} />
         <div className="flex items-center p-3 border-b border-black">
           <span className="text-2xl font-bold tracking-label uppercase leading-6">
@@ -74,7 +74,7 @@ export default function SplitResultPage() {
   if (!order && !isLoading) notFound();
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex flex-1 flex-col">
       <TopBar showBack onBack={() => router.push("/meal-plan")} />
 
       <div className="flex items-center p-3 border-b border-black">

--- a/ui/app/(authenticated)/invoice/page.tsx
+++ b/ui/app/(authenticated)/invoice/page.tsx
@@ -82,7 +82,7 @@ function InvoiceSetupContent() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex flex-1 flex-col">
       <TopBar showBack onBack={() => router.push("/meal-plan")} />
 
       <div className="flex items-center p-3 border-b border-black">

--- a/ui/app/(authenticated)/layout.tsx
+++ b/ui/app/(authenticated)/layout.tsx
@@ -2,7 +2,7 @@
 
 import { useAuth } from "@/lib/auth";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export default function AuthenticatedLayout({
   children,
@@ -11,6 +11,7 @@ export default function AuthenticatedLayout({
 }) {
   const { session, appUser, loading } = useAuth();
   const router = useRouter();
+  const [wasAuthed, setWasAuthed] = useState(false);
 
   useEffect(() => {
     if (loading) return;
@@ -18,12 +19,15 @@ export default function AuthenticatedLayout({
       router.replace("/login");
     } else if (!appUser) {
       router.replace("/onboarding");
+    } else {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setWasAuthed(true);
     }
   }, [session, appUser, loading, router]);
 
-  if (loading || !session || !appUser) {
-    return <div className="flex min-h-screen items-center justify-center" />;
+  if (!wasAuthed && (loading || !session || !appUser)) {
+    return <div className="flex flex-1 flex-col" />;
   }
 
-  return <>{children}</>;
+  return <div className="flex flex-1 flex-col">{children}</div>;
 }

--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -109,7 +109,7 @@ export default function MealPlanEditPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex flex-1 flex-col">
       <TopBar
         showBack
         onBack={mode === "reorder" ? () => setMode("select") : undefined}

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -22,7 +22,7 @@ export default function MealPlanPage() {
   const hasItems = items.length > 0;
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex flex-1 flex-col">
       <TopBar />
 
       <div className="flex items-stretch justify-between border-b border-black">

--- a/ui/app/auth/connect/splitwise/route.ts
+++ b/ui/app/auth/connect/splitwise/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get("code");
+  const state = searchParams.get("state");
+
+  if (!code || !state) {
+    return NextResponse.redirect(
+      new URL("/onboarding?splitwise=error", request.url),
+    );
+  }
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  const redirectUri = `${new URL(request.url).origin}/auth/connect/splitwise`;
+
+  const resp = await fetch(`${apiUrl}/api/v1/auth/splitwise/exchange`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code, state, redirect_uri: redirectUri }),
+  });
+
+  const path = resp.ok
+    ? "/onboarding?splitwise=success"
+    : "/onboarding?splitwise=error";
+  return NextResponse.redirect(new URL(path, request.url));
+}

--- a/ui/app/error.tsx
+++ b/ui/app/error.tsx
@@ -14,7 +14,7 @@ export default function ErrorPage({
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-dvh flex-col">
       <main className="flex flex-1 flex-col items-center justify-center p-3">
         <span className="text-2xl font-bold tracking-heading uppercase leading-6">
           Something went wrong

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${mono.variable} h-full`}>
+    <html lang="en" className={`${mono.variable} min-h-dvh`}>
       <head>
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -50,7 +50,7 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap"
         />
       </head>
-      <body className="min-h-full flex flex-col font-mono bg-white text-black">
+      <body className="min-h-dvh flex flex-col font-mono bg-white text-black">
         <Providers>
           <AuthProvider>{children}</AuthProvider>
         </Providers>

--- a/ui/app/login/page.tsx
+++ b/ui/app/login/page.tsx
@@ -36,11 +36,11 @@ export default function LoginPage() {
   }
 
   if (loading || session) {
-    return <div className="flex min-h-screen items-center justify-center" />;
+    return <div className="flex min-h-dvh items-center justify-center" />;
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center px-6">
+    <div className="flex min-h-dvh flex-col items-center justify-center px-6">
       <h1 className="text-2xl font-bold tracking-heading uppercase">
         CartWise
       </h1>

--- a/ui/app/not-found.tsx
+++ b/ui/app/not-found.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-dvh flex-col">
       <main className="flex flex-1 flex-col items-center justify-center p-3">
         <span className="text-2xl font-bold tracking-heading uppercase leading-6">
           Not found

--- a/ui/app/offline/page.tsx
+++ b/ui/app/offline/page.tsx
@@ -1,6 +1,6 @@
 export default function OfflinePage() {
   return (
-    <div className="flex min-h-screen items-center justify-center font-mono">
+    <div className="flex min-h-dvh items-center justify-center font-mono">
       <div className="p-3 text-center">
         <span className="text-2xl font-bold tracking-label uppercase leading-6">
           Offline

--- a/ui/app/onboarding/page.tsx
+++ b/ui/app/onboarding/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { Suspense, useState, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { Session } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/client";
 import apiClient from "@/lib/api/client";
 import { useAuth } from "@/lib/auth";
 
-export default function OnboardingPage() {
+function OnboardingContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { refreshAppUser } = useAuth();
@@ -129,5 +129,13 @@ export default function OnboardingPage() {
         )}
       </div>
     </div>
+  );
+}
+
+export default function OnboardingPage() {
+  return (
+    <Suspense fallback={<div className="flex min-h-dvh items-center justify-center"><p className="text-sm tracking-wider text-gray-600">Loading...</p></div>}>
+      <OnboardingContent />
+    </Suspense>
   );
 }

--- a/ui/app/onboarding/page.tsx
+++ b/ui/app/onboarding/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import type { Session } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/client";
 import apiClient from "@/lib/api/client";
@@ -9,15 +9,22 @@ import { useAuth } from "@/lib/auth";
 
 export default function OnboardingPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { refreshAppUser } = useAuth();
-  const [name, setName] = useState("");
-  const [phone, setPhone] = useState("");
-  const [splitwiseUserId, setSplitwiseUserId] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState("");
+
+  const swParam = searchParams.get("splitwise");
+  const initialStatus = swParam === "success" ? "done" : swParam === "error" ? "connecting" : "loading";
+
+  const [error, setError] = useState(swParam === "error" ? "Failed to connect Splitwise. Please try again." : "");
+  const [status, setStatus] = useState<"loading" | "connecting" | "done">(initialStatus);
   const [session, setSession] = useState<Session | null>(null);
-  const [ready, setReady] = useState(false);
-  const namePrefilledRef = useRef(false);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (swParam === "success") {
+      refreshAppUser().then(() => router.replace("/meal-plan"));
+    }
+  }, [swParam, refreshAppUser, router]);
 
   useEffect(() => {
     const supabase = createClient();
@@ -29,61 +36,62 @@ export default function OnboardingPage() {
         return;
       }
       setSession(session);
-
-      if (!namePrefilledRef.current) {
-        const meta = session.user?.user_metadata;
-        const googleName = meta?.full_name || meta?.name || "";
-        if (googleName) {
-          setName(googleName);
-          namePrefilledRef.current = true;
-        }
-      }
-
-      setReady(true);
     });
 
     const timeout = setTimeout(() => {
-      setReady((prev) => {
-        if (!prev) router.replace("/login");
-        return prev;
-      });
+      if (!session) router.replace("/login");
     }, 5000);
 
     return () => {
       subscription.unsubscribe();
       clearTimeout(timeout);
     };
-  }, [router]);
+  }, [router, session]);
 
-  if (!ready) {
-    return <div className="flex min-h-dvh items-center justify-center" />;
-  }
+  useEffect(() => {
+    if (!session || startedRef.current || swParam) return;
+    startedRef.current = true;
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+    async function run() {
+      const accessToken = session!.access_token;
+
+      await apiClient.POST("/api/v1/auth/onboard", {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      setStatus("connecting");
+      const { data, error: apiError } = await apiClient.POST(
+        "/api/v1/auth/splitwise/connect",
+        { headers: { Authorization: `Bearer ${accessToken}` } },
+      );
+
+      if (apiError || !data) {
+        setError("Failed to start Splitwise connection.");
+        return;
+      }
+
+      window.location.href = data.authorize_url;
+    }
+
+    run();
+  }, [session, swParam]);
+
+  async function handleRetry() {
+    if (!session) return;
     setError("");
-    setSubmitting(true);
+    setStatus("connecting");
 
-    const { error: apiError } = await apiClient.POST(
-      "/api/v1/auth/onboard",
-      {
-        headers: { Authorization: `Bearer ${session!.access_token}` },
-        body: {
-          name,
-          phone,
-          splitwise_user_id: splitwiseUserId ? parseInt(splitwiseUserId, 10) : undefined,
-        },
-      },
+    const { data, error: apiError } = await apiClient.POST(
+      "/api/v1/auth/splitwise/connect",
+      { headers: { Authorization: `Bearer ${session.access_token}` } },
     );
 
-    if (apiError) {
-      setError("Failed to complete setup. Please try again.");
-      setSubmitting(false);
+    if (apiError || !data) {
+      setError("Failed to start Splitwise connection.");
       return;
     }
 
-    await refreshAppUser();
-    router.replace("/");
+    window.location.href = data.authorize_url;
   }
 
   return (
@@ -94,69 +102,32 @@ export default function OnboardingPage() {
         </span>
       </header>
 
-      <form id="onboarding" onSubmit={handleSubmit} className="flex flex-1 flex-col justify-center p-3">
-        <div className="flex flex-col gap-8">
-          <div>
-            <label htmlFor="onboarding-name" className="text-xs font-bold tracking-label uppercase">
-              Name
-            </label>
-            <input
-              id="onboarding-name"
-              type="text"
-              required
-              autoComplete="name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Your name"
-              className="mt-2 block w-full border-b-2 border-black bg-transparent pb-2 text-base font-medium tracking-wider outline-none placeholder:text-gray-300"
-            />
-          </div>
+      <div className="flex flex-1 flex-col items-center justify-center p-3">
+        {status === "loading" && (
+          <p className="text-sm tracking-wider text-gray-600">Setting up your account...</p>
+        )}
 
-          <div>
-            <label htmlFor="onboarding-phone" className="text-xs font-bold tracking-label uppercase">
-              Phone
-            </label>
-            <input
-              id="onboarding-phone"
-              type="tel"
-              required
-              autoComplete="tel"
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-              placeholder="0000000000"
-              pattern="[0-9]{10}"
-              className="mt-2 block w-full border-b-2 border-black bg-transparent pb-2 text-base font-medium tracking-wider outline-none placeholder:text-gray-300"
-            />
-          </div>
-
-          <div>
-            <label htmlFor="onboarding-splitwise-id" className="text-xs font-bold tracking-label uppercase">
-              Splitwise User ID
-            </label>
-            <input
-              id="onboarding-splitwise-id"
-              type="number"
-              value={splitwiseUserId}
-              onChange={(e) => setSplitwiseUserId(e.target.value)}
-              placeholder="00000"
-              className="mt-2 block w-full border-b-2 border-black bg-transparent pb-2 text-base font-medium tracking-wider outline-none placeholder:text-gray-300"
-            />
-          </div>
-        </div>
+        {status === "connecting" && !error && (
+          <p className="text-sm tracking-wider text-gray-600">Connecting to Splitwise...</p>
+        )}
 
         {error && (
-          <p className="mt-4 text-xs text-red-600 tracking-wider">{error}</p>
+          <div className="flex flex-col items-center gap-4">
+            <p className="text-xs text-red-600 tracking-wider">{error}</p>
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="flex items-center justify-center border-2 border-black px-6 py-3 text-base font-bold tracking-label uppercase"
+            >
+              Try Again
+            </button>
+          </div>
         )}
-      </form>
 
-      <button
-        type="submit"
-        form="onboarding"
-        disabled={submitting}
-        className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:opacity-50"
-      >
-        {submitting ? "Connecting..." : "Connect to Splitwise"}
-      </button>
+        {status === "done" && (
+          <p className="text-sm tracking-wider text-gray-600">Connected! Redirecting...</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/ui/app/onboarding/page.tsx
+++ b/ui/app/onboarding/page.tsx
@@ -56,7 +56,7 @@ export default function OnboardingPage() {
   }, [router]);
 
   if (!ready) {
-    return <div className="flex min-h-screen items-center justify-center" />;
+    return <div className="flex min-h-dvh items-center justify-center" />;
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -71,7 +71,7 @@ export default function OnboardingPage() {
         body: {
           name,
           phone,
-          splitwise_user_id: parseInt(splitwiseUserId, 10),
+          splitwise_user_id: splitwiseUserId ? parseInt(splitwiseUserId, 10) : undefined,
         },
       },
     );
@@ -87,7 +87,7 @@ export default function OnboardingPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-dvh flex-col">
       <header className="flex items-center justify-center p-3 border-b border-black">
         <span className="text-2xl font-bold tracking-heading uppercase leading-6">
           CartWise
@@ -136,7 +136,6 @@ export default function OnboardingPage() {
             <input
               id="onboarding-splitwise-id"
               type="number"
-              required
               value={splitwiseUserId}
               onChange={(e) => setSplitwiseUserId(e.target.value)}
               placeholder="00000"

--- a/ui/components/menu-item-page.tsx
+++ b/ui/components/menu-item-page.tsx
@@ -276,7 +276,7 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
   const showEditButton = !isNew && !editing;
 
   return (
-    <div className="flex min-h-screen flex-col [overflow-anchor:none]">
+    <div className="flex flex-1 flex-col [overflow-anchor:none]">
       {/* TopBar — scrolls away (not sticky). The observer watches this
           element; when it leaves the viewport the sticky heading truncates. */}
       <div ref={sentinelRef}>

--- a/ui/components/top-bar.tsx
+++ b/ui/components/top-bar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import Image from "next/image";
 import { Icon } from "@/components/icon";
 
 interface TopBarProps {
@@ -26,9 +25,9 @@ export function TopBar({ showBack = false, onBack, rightAction }: TopBarProps) {
       </div>
 
       <div className="flex items-center gap-1 h-12">
-        <Image src="/logo-grocery.avif" alt="" width={36} height={36} className="object-contain" unoptimized />
-        <Image src="/logo-calculator.avif" alt="" width={36} height={36} className="object-contain" unoptimized />
-        <Image src="/logo-pizza.avif" alt="" width={36} height={36} className="object-contain" unoptimized />
+        <img src="/logo-grocery.avif" alt="" width={36} height={36} className="object-contain" />
+        <img src="/logo-calculator.avif" alt="" width={36} height={36} className="object-contain" />
+        <img src="/logo-pizza.avif" alt="" width={36} height={36} className="object-contain" />
       </div>
 
       <div className="w-12 shrink-0 flex items-stretch">{rightAction}</div>

--- a/ui/lib/api/schema.d.ts
+++ b/ui/lib/api/schema.d.ts
@@ -600,6 +600,13 @@ export interface components {
             /** Splitwise Expense Id */
             splitwise_expense_id: number | null;
         };
+        /** SplitwiseConnectResponse */
+        SplitwiseConnectResponse: {
+            /** Authorize Url */
+            authorize_url: string;
+            /** Redirect Uri */
+            redirect_uri: string;
+        };
         /** SplitwiseExchangeRequest */
         SplitwiseExchangeRequest: {
             /** Code */
@@ -725,7 +732,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["SplitwiseConnectResponse"];
                 };
             };
         };

--- a/ui/lib/api/schema.d.ts
+++ b/ui/lib/api/schema.d.ts
@@ -40,10 +40,56 @@ export interface paths {
          * @description Complete onboarding — creates the user record in the DB.
          *
          *     Requires a valid Supabase JWT. The user must NOT already exist.
-         *     OAuth claims (email, avatar, provider) come from the JWT.
-         *     Name, phone, and splitwise_user_id come from the request body.
+         *     All user fields (email, name, avatar, provider) come from JWT claims.
          */
         post: operations["onboard_api_v1_auth_onboard_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/splitwise/connect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Splitwise Connect
+         * @description Start the Splitwise OAuth flow.
+         *
+         *     Returns an authorize_url the frontend navigates to, plus the redirect_uri
+         *     that the frontend callback route must echo back during token exchange.
+         */
+        post: operations["splitwise_connect_api_v1_auth_splitwise_connect_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/splitwise/exchange": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Splitwise Exchange
+         * @description Exchange a Splitwise authorization code for an access token.
+         *
+         *     Called by the frontend callback route after Splitwise redirects back.
+         *     The frontend forwards code + state + redirect_uri; backend handles
+         *     token exchange, stores the token in Vault, and returns success/failure.
+         */
+        post: operations["splitwise_exchange_api_v1_auth_splitwise_exchange_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -482,15 +528,6 @@ export interface components {
             /** Body */
             body?: string | null;
         };
-        /** OnboardRequest */
-        OnboardRequest: {
-            /** Name */
-            name: string;
-            /** Phone */
-            phone: string;
-            /** Splitwise User Id */
-            splitwise_user_id: number;
-        };
         /** OrderParticipantResponse */
         OrderParticipantResponse: {
             /**
@@ -563,6 +600,15 @@ export interface components {
             /** Splitwise Expense Id */
             splitwise_expense_id: number | null;
         };
+        /** SplitwiseExchangeRequest */
+        SplitwiseExchangeRequest: {
+            /** Code */
+            code: string;
+            /** State */
+            state: string;
+            /** Redirect Uri */
+            redirect_uri: string;
+        };
         /** UserResponse */
         UserResponse: {
             /**
@@ -574,14 +620,14 @@ export interface components {
             email: string;
             /** Name */
             name: string;
-            /** Phone */
-            phone: string | null;
             /** Avatar Url */
             avatar_url: string | null;
             /** Oauth Provider */
             oauth_provider: string;
             /** Splitwise User Id */
             splitwise_user_id: number | null;
+            /** Splitwise Connected */
+            splitwise_connected: boolean;
             /** Is Active */
             is_active: boolean;
             /**
@@ -599,8 +645,6 @@ export interface components {
         UserUpdate: {
             /** Name */
             name?: string | null;
-            /** Phone */
-            phone?: string | null;
             /** Avatar Url */
             avatar_url?: string | null;
         };
@@ -653,11 +697,7 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["OnboardRequest"];
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             201: {
@@ -666,6 +706,50 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UserResponse"];
+                };
+            };
+        };
+    };
+    splitwise_connect_api_v1_auth_splitwise_connect_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    splitwise_exchange_api_v1_auth_splitwise_exchange_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SplitwiseExchangeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/ui/lib/auth.tsx
+++ b/ui/lib/auth.tsx
@@ -16,9 +16,9 @@ interface AppUser {
   id: string;
   email: string;
   name: string;
-  phone: string | null;
   avatar_url: string | null;
   splitwise_user_id: number | null;
+  splitwise_connected: boolean;
 }
 
 interface AuthContextType {

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -16,6 +16,7 @@ const withSerwist = withSerwistInit({
 
 const nextConfig: NextConfig = {
   turbopack: {},
+  allowedDevOrigins: ["lr602lw45l.taile1dca.ts.net"],
   async redirects() {
     return [
       {

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --hostname 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
## Summary

- Adds Splitwise OAuth 2.0 connect/exchange endpoints with HMAC-signed state (no session cookies)
- Stores per-user Splitwise tokens in Supabase Vault
- Frontend onboarding page with "Connect Splitwise" button and callback route at `/auth/connect/splitwise`
- Local dev always hits mock Splitwise server (port 8001); only production connects to real Splitwise
- User model: adds `splitwise_user_id` + `splitwise_connected_at`, drops unused `phone` column

## Test plan

- [x] 130 unit tests pass (14 new for Splitwise auth)
- [x] Ruff lint + format clean
- [x] ESLint clean
- [x] End-to-end browser test: login → onboard → mock Splitwise OAuth → callback at `/auth/connect/splitwise` → exchange → success → DB updated (`splitwise_connected: true`)
- [ ] Verify production Splitwise app callback URL matches `/auth/connect/splitwise`