### PR TITLE
feat(ui): logout flow + HTTPS reverse-proxy fixes

### DIFF
--- a/backend/settings.toml
+++ b/backend/settings.toml
@@ -39,8 +39,8 @@ MOCK_SERVER_PORT = 8001
 [development]
 DEBUG = true
 SPLITWISE_ENABLED = true
-CORS_ORIGINS = ["http://lr602lw45l.taile1dca.ts.net:3000", "http://localhost:3000"]
-FRONTEND_URL = "http://lr602lw45l.taile1dca.ts.net:3000"
+CORS_ORIGINS = ["https://lr602lw45l.taile1dca.ts.net", "http://localhost:3000"]
+FRONTEND_URL = "https://lr602lw45l.taile1dca.ts.net"
 SESSION_SECRET_KEY = "dev-session-secret-not-for-production"
 
 [testing]

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -6,6 +6,7 @@ import { $api } from "@/lib/api/hooks";
 import { TopBar } from "@/components/top-bar";
 import { MealPlanItem } from "@/components/meal-plan-item";
 import { Icon } from "@/components/icon";
+import { LogoutButton } from "@/components/logout-button";
 import { useRouter } from "next/navigation";
 
 export default function MealPlanPage() {
@@ -15,15 +16,17 @@ export default function MealPlanPage() {
   const { data: mealPlan, isLoading } = $api.useQuery(
     "get",
     "/api/v1/meal-plans/{user_id}",
-    { params: { path: { user_id: appUser!.id } } },
+    { params: { path: { user_id: appUser?.id ?? "" } }, enabled: !!appUser },
   );
+
+  if (!appUser) return null;
 
   const items = mealPlan?.items ?? [];
   const hasItems = items.length > 0;
 
   return (
     <div className="flex flex-1 flex-col">
-      <TopBar />
+      <TopBar rightAction={<LogoutButton />} />
 
       <div className="flex items-stretch justify-between border-b border-black">
         <span className="flex items-center p-3 text-2xl font-bold tracking-label uppercase leading-6">

--- a/ui/app/auth/callback/route.ts
+++ b/ui/app/auth/callback/route.ts
@@ -1,15 +1,20 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+function baseUrl(request: NextRequest): string {
+  const proto = request.headers.get("x-forwarded-proto") || "http";
+  const host = request.headers.get("x-forwarded-host") || request.headers.get("host") || "localhost:3000";
+  return `${proto}://${host}`;
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get("code");
-  const redirectUrl = new URL("/", request.url);
 
   if (code) {
     const supabase = await createClient();
     await supabase.auth.exchangeCodeForSession(code);
   }
 
-  return NextResponse.redirect(redirectUrl);
+  return NextResponse.redirect(new URL("/", baseUrl(request)));
 }

--- a/ui/app/auth/connect/splitwise/route.ts
+++ b/ui/app/auth/connect/splitwise/route.ts
@@ -1,18 +1,23 @@
 import { NextResponse, type NextRequest } from "next/server";
 
+function baseUrl(request: NextRequest): string {
+  const proto = request.headers.get("x-forwarded-proto") || "http";
+  const host = request.headers.get("x-forwarded-host") || request.headers.get("host") || "localhost:3000";
+  return `${proto}://${host}`;
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get("code");
   const state = searchParams.get("state");
+  const origin = baseUrl(request);
 
   if (!code || !state) {
-    return NextResponse.redirect(
-      new URL("/onboarding?splitwise=error", request.url),
-    );
+    return NextResponse.redirect(new URL("/onboarding?splitwise=error", origin));
   }
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-  const redirectUri = `${new URL(request.url).origin}/auth/connect/splitwise`;
+  const redirectUri = `${origin}/auth/connect/splitwise`;
 
   const resp = await fetch(`${apiUrl}/api/v1/auth/splitwise/exchange`, {
     method: "POST",
@@ -23,5 +28,5 @@ export async function GET(request: NextRequest) {
   const path = resp.ok
     ? "/onboarding?splitwise=success"
     : "/onboarding?splitwise=error";
-  return NextResponse.redirect(new URL(path, request.url));
+  return NextResponse.redirect(new URL(path, origin));
 }

--- a/ui/app/onboarding/page.tsx
+++ b/ui/app/onboarding/page.tsx
@@ -2,51 +2,33 @@
 
 import { Suspense, useState, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import type { Session } from "@supabase/supabase-js";
-import { createClient } from "@/lib/supabase/client";
 import apiClient from "@/lib/api/client";
 import { useAuth } from "@/lib/auth";
 
 function OnboardingContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { refreshAppUser } = useAuth();
+  const { session, loading, refreshAppUser } = useAuth();
 
   const swParam = searchParams.get("splitwise");
   const initialStatus = swParam === "success" ? "done" : swParam === "error" ? "connecting" : "loading";
 
   const [error, setError] = useState(swParam === "error" ? "Failed to connect Splitwise. Please try again." : "");
   const [status, setStatus] = useState<"loading" | "connecting" | "done">(initialStatus);
-  const [session, setSession] = useState<Session | null>(null);
   const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!session) {
+      router.replace("/login");
+    }
+  }, [loading, session, router]);
 
   useEffect(() => {
     if (swParam === "success") {
       refreshAppUser().then(() => router.replace("/meal-plan"));
     }
   }, [swParam, refreshAppUser, router]);
-
-  useEffect(() => {
-    const supabase = createClient();
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (!session) {
-        router.replace("/login");
-        return;
-      }
-      setSession(session);
-    });
-
-    const timeout = setTimeout(() => {
-      if (!session) router.replace("/login");
-    }, 5000);
-
-    return () => {
-      subscription.unsubscribe();
-      clearTimeout(timeout);
-    };
-  }, [router, session]);
 
   useEffect(() => {
     if (!session || startedRef.current || swParam) return;
@@ -93,6 +75,8 @@ function OnboardingContent() {
 
     window.location.href = data.authorize_url;
   }
+
+  if (loading || !session) return null;
 
   return (
     <div className="flex min-h-dvh flex-col">

--- a/ui/components/logout-button.tsx
+++ b/ui/components/logout-button.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useAuth } from "@/lib/auth";
+import { Icon } from "@/components/icon";
+
+export function LogoutButton() {
+  const { signOut } = useAuth();
+
+  return (
+    <button
+      onClick={signOut}
+      aria-label="Sign out"
+      className="flex h-full w-full items-center justify-center"
+    >
+      <Icon name="logout" size={24} />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a logout button (top-right of meal-plan page) that calls `signOut()` and redirects to `/login`
- Fixes auth callback route handlers to respect `x-forwarded-proto`/`x-forwarded-host` headers — previously they used raw `request.url` which resolved to `0.0.0.0:3000` behind Tailscale Serve
- Refactors onboarding page to use `useAuth()` context instead of a duplicate Supabase `onAuthStateChange` subscription that caused infinite re-renders (100% CPU)
- Switches dev CORS origins and `FRONTEND_URL` to HTTPS via Tailscale Serve

## Test plan
- [ ] Navigate to `/meal-plan` → logout icon visible in top-right
- [ ] Tap logout → redirected to `/login`, cannot access `/meal-plan` without re-authenticating
- [ ] Full onboarding flow works over `https://lr602lw45l.taile1dca.ts.net`: login → onboard → Splitwise connect → meal-plan
- [ ] Auth callback redirects to correct HTTPS origin (not `0.0.0.0`)