### PR TITLE
feat: account deletion with profile page and cascade deletes

### DIFF
--- a/backend/alembic/versions/3df8ef3688f7_add_cascade_delete_on_user_fks.py
+++ b/backend/alembic/versions/3df8ef3688f7_add_cascade_delete_on_user_fks.py
@@ -1,0 +1,45 @@
+"""add cascade delete on user fks
+
+Revision ID: 3df8ef3688f7
+Revises: b2c3d4e5f6a7
+Create Date: 2026-05-01 02:56:40.076120
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3df8ef3688f7"
+down_revision: Union[str, Sequence[str], None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add ON DELETE CASCADE to all foreign keys referencing users.id."""
+    fks = [
+        ("meal_plans", "meal_plans_user_id_fkey", "user_id"),
+        ("menu_items", "menu_items_created_by_fkey", "created_by"),
+        ("menu_items", "menu_items_updated_by_fkey", "updated_by"),
+        ("order_participants", "order_participants_user_id_fkey", "user_id"),
+        ("orders", "orders_paid_by_fkey", "paid_by"),
+    ]
+    for table, constraint, column in fks:
+        op.drop_constraint(constraint, table, type_="foreignkey")
+        op.create_foreign_key(constraint, table, "users", [column], ["id"], ondelete="CASCADE")
+
+
+def downgrade() -> None:
+    """Remove ON DELETE CASCADE (revert to default RESTRICT)."""
+    fks = [
+        ("meal_plans", "meal_plans_user_id_fkey", "user_id"),
+        ("menu_items", "menu_items_created_by_fkey", "created_by"),
+        ("menu_items", "menu_items_updated_by_fkey", "updated_by"),
+        ("order_participants", "order_participants_user_id_fkey", "user_id"),
+        ("orders", "orders_paid_by_fkey", "paid_by"),
+    ]
+    for table, constraint, column in fks:
+        op.drop_constraint(constraint, table, type_="foreignkey")
+        op.create_foreign_key(constraint, table, "users", [column], ["id"])

--- a/backend/app/models/meal_plan.py
+++ b/backend/app/models/meal_plan.py
@@ -15,7 +15,7 @@ class MealPlan(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("users.id"), unique=True
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), unique=True
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/app/models/menu_item.py
+++ b/backend/app/models/menu_item.py
@@ -16,8 +16,12 @@ class MenuItem(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(String(255))
     body: Mapped[str] = mapped_column(Text)
-    created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
-    updated_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE")
+    )
+    updated_by: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE")
+    )
     status: Mapped[str] = mapped_column(String(20), default="active")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -14,7 +14,9 @@ class Order(Base):
     __tablename__ = "orders"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    paid_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
+    paid_by: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE")
+    )
     invoice_filename: Mapped[str] = mapped_column(String(500))
     status: Mapped[str] = mapped_column(String(20), default="draft")
     snapshot: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
@@ -36,7 +38,7 @@ class OrderParticipant(Base):
         UUID(as_uuid=True), ForeignKey("orders.id", ondelete="CASCADE"), primary_key=True
     )
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("users.id"), primary_key=True
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
     )
 
     # Relationships

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -26,9 +26,11 @@ from app.auth.dependencies import CurrentUser, security
 from app.auth.jwt import create_test_token, decode_supabase_jwt
 from app.config import settings
 from app.database import SessionDep
+from app.models.order import Order
 from app.models.user import User
 from app.schemas.user import UserResponse
-from app.services.vault import store_secret
+from app.services.storage import delete_order_files
+from app.services.vault import delete_secret, store_secret
 
 _signer = URLSafeTimedSerializer(settings.SESSION_SECRET_KEY)
 STATE_MAX_AGE = 600  # 10 minutes
@@ -56,6 +58,37 @@ async def get_me(current_user: CurrentUser):
     Returns 404 if the user hasn't completed onboarding yet.
     """
     return current_user
+
+
+class DeleteAccountRequest(BaseModel):
+    action: str
+
+
+@router.delete("/me")
+async def delete_account(
+    body: DeleteAccountRequest, current_user: CurrentUser, session: SessionDep
+):
+    """Permanently delete the current user's account and all associated data."""
+    if body.action != "delete":
+        raise HTTPException(status_code=400, detail="Must confirm with action: 'delete'")
+
+    # 1. Delete vault secret (Splitwise token)
+    await delete_secret(session, f"splitwise_token:{current_user.id}")
+
+    # 2. Delete storage files for user's orders
+    import asyncio
+
+    result = await session.execute(select(Order).where(Order.paid_by == current_user.id))
+    for order in result.scalars():
+        await asyncio.to_thread(delete_order_files, order.id)
+
+    # 3. Delete user — DB CASCADE handles all related rows
+    from sqlalchemy import delete
+
+    await session.execute(delete(User).where(User.id == current_user.id))
+    await session.commit()
+
+    return {"detail": "Account deleted"}
 
 
 @router.post("/onboard", response_model=UserResponse, status_code=201)

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -82,3 +82,21 @@ def download_to_temp(storage_path: str) -> str:
 
     # Fallback: the storage_path IS the local path
     return storage_path
+
+
+def delete_order_files(order_id: uuid.UUID) -> None:
+    """Delete all stored files for an order.
+
+    Sync function — call via asyncio.to_thread() in async context.
+    """
+    import shutil
+
+    if _is_real_supabase():
+        client = _get_supabase_client()
+        path = _storage_path(order_id)
+        client.storage.from_(BUCKET).remove([path])
+        return
+
+    local_dir = Path(settings.get("STORAGE_DIR", "./storage")) / "orders" / str(order_id)
+    if local_dir.exists():
+        shutil.rmtree(local_dir)

--- a/ui/app/(authenticated)/layout.tsx
+++ b/ui/app/(authenticated)/layout.tsx
@@ -17,7 +17,7 @@ export default function AuthenticatedLayout({
     if (loading) return;
     if (!session) {
       router.replace("/login");
-    } else if (!appUser) {
+    } else if (!appUser || !appUser.splitwise_connected) {
       router.replace("/onboarding");
     } else {
       // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -25,7 +25,7 @@ export default function AuthenticatedLayout({
     }
   }, [session, appUser, loading, router]);
 
-  if (!wasAuthed && (loading || !session || !appUser)) {
+  if (!wasAuthed && (loading || !session || !appUser || !appUser.splitwise_connected)) {
     return <div className="flex flex-1 flex-col" />;
   }
 

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -6,7 +6,6 @@ import { $api } from "@/lib/api/hooks";
 import { TopBar } from "@/components/top-bar";
 import { MealPlanItem } from "@/components/meal-plan-item";
 import { Icon } from "@/components/icon";
-import { LogoutButton } from "@/components/logout-button";
 import { useRouter } from "next/navigation";
 
 export default function MealPlanPage() {
@@ -26,7 +25,25 @@ export default function MealPlanPage() {
 
   return (
     <div className="flex flex-1 flex-col">
-      <TopBar rightAction={<LogoutButton />} />
+      <TopBar
+        rightAction={
+          <button
+            onClick={() => router.push("/profile")}
+            aria-label="Profile"
+            className="flex h-full w-full items-center justify-center"
+          >
+            {appUser.avatar_url ? (
+              <img
+                src={appUser.avatar_url}
+                alt=""
+                className="h-9 w-9 rounded-full object-cover"
+              />
+            ) : (
+              <Icon name="account_circle" size={36} />
+            )}
+          </button>
+        }
+      />
 
       <div className="flex items-stretch justify-between border-b border-black">
         <span className="flex items-center p-3 text-2xl font-bold tracking-label uppercase leading-6">

--- a/ui/app/(authenticated)/profile/page.tsx
+++ b/ui/app/(authenticated)/profile/page.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth";
+import { TopBar } from "@/components/top-bar";
+import { Icon } from "@/components/icon";
+import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog";
+import apiClient from "@/lib/api/client";
+
+export default function ProfilePage() {
+  const { appUser, signOut } = useAuth();
+  const router = useRouter();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState("");
+
+  if (!appUser) return null;
+
+  async function handleDelete() {
+    setDeleting(true);
+    setError("");
+
+    const { error: apiError } = await apiClient.DELETE("/api/v1/auth/me", {
+      body: { action: "delete" },
+    });
+
+    if (apiError) {
+      setError("Failed to delete account. Please try again.");
+      setDeleting(false);
+      return;
+    }
+
+    await signOut();
+    router.replace("/login");
+  }
+
+  return (
+    <div className="flex flex-1 flex-col">
+      <TopBar showBack onBack={() => router.push("/meal-plan")} />
+
+      <div className="flex h-12 items-center border-b border-black gap-3">
+        <div className="flex w-12 shrink-0 items-center justify-center">
+          {appUser.avatar_url ? (
+            <img
+              src={appUser.avatar_url}
+              alt=""
+              className="h-9 w-9 rounded-full object-cover"
+            />
+          ) : (
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-black text-white">
+              <Icon name="person" size={20} />
+            </div>
+          )}
+        </div>
+        <span className="text-2xl font-bold tracking-label uppercase leading-6">
+          {appUser.name}
+        </span>
+      </div>
+
+      <main className="flex flex-1 flex-col p-3">
+        <p className="text-sm text-gray-600">{appUser.email}</p>
+
+        <div className="flex items-center gap-2 mt-3">
+          <Icon name={appUser.splitwise_connected ? "check_circle" : "cancel"} size={20} />
+          <span className="text-sm tracking-wider">
+            {appUser.splitwise_connected ? "Splitwise connected" : "Splitwise not connected"}
+          </span>
+        </div>
+
+        {error && (
+          <p className="text-xs text-red-600 tracking-wider mt-3">{error}</p>
+        )}
+
+        <div className="mt-auto flex flex-col gap-3">
+          <button
+            onClick={signOut}
+            className="flex items-center justify-center border border-black p-3 text-base font-bold tracking-label uppercase"
+          >
+            Sign Out
+          </button>
+
+          <button
+            onClick={() => setShowDeleteDialog(true)}
+            className="flex items-center justify-center border border-black p-3 text-base font-bold tracking-label uppercase text-red-600"
+          >
+            Delete Account
+          </button>
+        </div>
+      </main>
+
+      {showDeleteDialog && (
+        <ConfirmDeleteDialog
+          onConfirm={handleDelete}
+          onCancel={() => setShowDeleteDialog(false)}
+          loading={deleting}
+        />
+      )}
+    </div>
+  );
+}

--- a/ui/components/confirm-delete-dialog.tsx
+++ b/ui/components/confirm-delete-dialog.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+
+interface ConfirmDeleteDialogProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading?: boolean;
+}
+
+export function ConfirmDeleteDialog({ onConfirm, onCancel, loading }: ConfirmDeleteDialogProps) {
+  const [input, setInput] = useState("");
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="delete-title"
+      aria-describedby="delete-message"
+    >
+      <div className="bg-white border border-black p-3 mx-3 max-w-sm w-full">
+        <p id="delete-title" className="text-2xl font-bold tracking-label uppercase leading-6">
+          Delete Account
+        </p>
+        <p id="delete-message" className="text-base leading-6 mt-3">
+          This will permanently delete your account and all your data. This cannot be undone.
+        </p>
+        <input
+          type="text"
+          placeholder="Type delete to confirm"
+          value={input}
+          onChange={(e) => setInput(e.target.value.toLowerCase())}
+          className="mt-3 w-full border border-black p-3 text-base tracking-wider"
+          autoFocus
+        />
+        <div className="mt-3 flex gap-3">
+          <button
+            onClick={onCancel}
+            disabled={loading}
+            className="flex-1 border border-black p-3 text-base font-bold tracking-label uppercase"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={input !== "delete" || loading}
+            className="flex-1 bg-black p-3 text-base font-bold tracking-label uppercase text-white disabled:opacity-30"
+          >
+            {loading ? "Deleting..." : "Delete"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/lib/api/schema.d.ts
+++ b/ui/lib/api/schema.d.ts
@@ -20,7 +20,11 @@ export interface paths {
         get: operations["get_me_api_v1_auth_me_get"];
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete Account
+         * @description Permanently delete the current user's account and all associated data.
+         */
+        delete: operations["delete_account_api_v1_auth_me_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -420,6 +424,11 @@ export interface components {
             /** Participant Ids */
             participant_ids: string;
         };
+        /** DeleteAccountRequest */
+        DeleteAccountRequest: {
+            /** Action */
+            action: string;
+        };
         /** DevLoginRequest */
         DevLoginRequest: {
             /** Email */
@@ -693,6 +702,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UserResponse"];
+                };
+            };
+        };
+    };
+    delete_account_api_v1_auth_me_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DeleteAccountRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- Add `DELETE /api/v1/auth/me` endpoint — deletes vault secrets, storage files, and user record (ON DELETE CASCADE handles all related rows)
- Add DB migration to set `ON DELETE CASCADE` on all user-referencing foreign keys
- New profile page (`/profile`) with user avatar, name, email, Splitwise status, sign out, and account deletion
- Confirmation dialog requiring user to type "delete" before proceeding
- Replace logout button in TopBar with user avatar linking to profile
- Guard authenticated layout to redirect users without Splitwise connection to onboarding

Closes #58

## Test plan

- [x] `CARTWISE_ENV=development uv run alembic upgrade head` — migration applies
- [x] `uv run pytest --ignore=tests/test_integration.py -v` — 130 tests pass
- [x] `cd ui && npx tsc --noEmit` — type-check passes
- [x] Browser: `/profile` shows user info, Splitwise status, sign out, delete
- [x] Browser: Type "delete" → confirm → account deleted → redirected to `/login`
- [x] Verify cascade: all user-related rows (meal_plans, menu_items, orders) cleaned up