### PR TITLE
fix: add ownership guard to menu item mutations

### DIFF
--- a/backend/app/routes/menu_items.py
+++ b/backend/app/routes/menu_items.py
@@ -13,6 +13,16 @@ from app.schemas.menu_item import MenuItemCreate, MenuItemResponse, MenuItemUpda
 router = APIRouter(prefix="/menu-items", tags=["menu-items"])
 
 
+async def _get_own_item(session, item_id: uuid.UUID, user_id: uuid.UUID) -> MenuItem:
+    result = await session.execute(
+        select(MenuItem).where(MenuItem.id == item_id, MenuItem.created_by == user_id)
+    )
+    item = result.scalar_one_or_none()
+    if not item:
+        raise HTTPException(status_code=404, detail="Menu item not found")
+    return item
+
+
 @router.post("/", response_model=MenuItemResponse, status_code=201)
 async def create_menu_item(
     data: MenuItemCreate,
@@ -59,9 +69,7 @@ async def update_menu_item(
     session: SessionDep,
     current_user: CurrentUser,
 ):
-    item = await session.get(MenuItem, item_id)
-    if not item:
-        raise HTTPException(status_code=404, detail="Menu item not found")
+    item = await _get_own_item(session, item_id, current_user.id)
 
     update_data = data.model_dump(exclude_unset=True)
     for key, value in update_data.items():
@@ -79,14 +87,11 @@ async def archive_menu_item(
     session: SessionDep,
     current_user: CurrentUser,
 ):
-    item = await session.get(MenuItem, item_id)
-    if not item:
-        raise HTTPException(status_code=404, detail="Menu item not found")
+    item = await _get_own_item(session, item_id, current_user.id)
 
     item.status = "archived"
     item.updated_by = current_user.id
 
-    # Auto-remove from user's meal plan if present
     result = await session.execute(
         select(MealPlan)
         .where(MealPlan.user_id == current_user.id)
@@ -107,9 +112,7 @@ async def unarchive_menu_item(
     session: SessionDep,
     current_user: CurrentUser,
 ):
-    item = await session.get(MenuItem, item_id)
-    if not item:
-        raise HTTPException(status_code=404, detail="Menu item not found")
+    item = await _get_own_item(session, item_id, current_user.id)
 
     item.status = "active"
     item.updated_by = current_user.id

--- a/backend/tests/test_menu_items.py
+++ b/backend/tests/test_menu_items.py
@@ -166,3 +166,43 @@ async def test_unarchive_not_found(client: AsyncClient, auth_headers: dict):
         f"/api/v1/menu-items/{uuid.uuid4()}/unarchive", headers=auth_headers
     )
     assert response.status_code == 404
+
+
+async def test_update_other_users_item_returns_404(
+    client: AsyncClient, auth_headers: dict, session
+):
+    """Users cannot modify menu items they don't own."""
+    from app.auth.jwt import create_test_token
+    from app.models.user import User
+
+    created = await client.post(
+        "/api/v1/menu-items/",
+        json={"name": "Private", "body": "owner only"},
+        headers=auth_headers,
+    )
+    item_id = created.json()["id"]
+
+    other_user = User(
+        email="other@example.com",
+        name="Other",
+        oauth_provider="google",
+        oauth_id="other-oauth-id",
+    )
+    session.add(other_user)
+    await session.commit()
+    other_token = create_test_token(other_user.oauth_id, other_user.email)
+    other_headers = {"Authorization": f"Bearer {other_token}"}
+
+    assert (
+        await client.patch(
+            f"/api/v1/menu-items/{item_id}", json={"name": "Hacked"}, headers=other_headers
+        )
+    ).status_code == 404
+
+    assert (
+        await client.patch(f"/api/v1/menu-items/{item_id}/archive", headers=other_headers)
+    ).status_code == 404
+
+    assert (
+        await client.patch(f"/api/v1/menu-items/{item_id}/unarchive", headers=other_headers)
+    ).status_code == 404


### PR DESCRIPTION
## Summary

- Add `created_by == current_user.id` check to update, archive, and unarchive endpoints
- Returns 404 (not 403) to avoid revealing existence of other users' items
- Add test verifying a second user gets 404 on all three mutation endpoints

Closes #62

## Test plan

- [x] `uv run pytest --ignore=tests/test_integration.py -v` — 131 tests pass
- [x] New test `test_update_other_users_item_returns_404` covers update, archive, unarchive