### PR TITLE
fix: normalize DATABASE_URL to use asyncpg driver

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -6,7 +6,7 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
-from app.config import settings
+from app.config import get_async_database_url
 from app.models import Base
 
 # this is the Alembic Config object, which provides
@@ -23,7 +23,7 @@ if config.config_file_name is not None:
 target_metadata = Base.metadata
 
 # Override sqlalchemy.url from settings
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", get_async_database_url())
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,3 +10,10 @@ settings = Dynaconf(
         Validator("SUPABASE_URL", must_exist=True),
     ],
 )
+
+
+def get_async_database_url() -> str:
+    url = settings.DATABASE_URL
+    if url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    return url

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -4,9 +4,9 @@ from typing import Annotated
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from app.config import settings
+from app.config import get_async_database_url
 
-engine = create_async_engine(settings.database_url, echo=False)
+engine = create_async_engine(get_async_database_url(), echo=False)
 
 async_session = async_sessionmaker(engine, expire_on_commit=False)
 


### PR DESCRIPTION
## Summary

- Deploy pipeline failed because Supabase provides `postgresql://` URLs but SQLAlchemy async engine requires `postgresql+asyncpg://`
- Added `get_async_database_url()` in `app/config.py` that transparently converts the scheme
- Updated `database.py` and `alembic/env.py` to use it

## Context

Fixes the CI migration failure from #65's first deploy attempt. The `DATABASE_URL` GitHub secret (from Supabase transaction pooler) starts with `postgresql://` — this helper ensures it works with asyncpg without requiring users to manually add the driver prefix.