### PR TITLE
ci: add workflow_dispatch and self-trigger to deploy workflow

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -3,7 +3,8 @@ name: Deploy Backend
 on:
   push:
     branches: [main]
-    paths: ['backend/**']
+    paths: ['backend/**', '.github/workflows/deploy-backend.yml']
+  workflow_dispatch:
 
 concurrency:
   group: deploy-backend


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger so deploys can be manually triggered
- Adds `.github/workflows/deploy-backend.yml` to the paths filter so workflow changes also trigger a deploy

This merge will trigger the first successful deploy since the `DATABASE_URL_MIGRATE` secret is now configured correctly.