### PR TITLE
fix: set UV_CACHE_DIR for non-root Google base image

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -3,7 +3,8 @@ name: Deploy Backend
 on:
   push:
     branches: [main]
-    paths: ['backend/**']
+    paths: ['backend/**', '.github/workflows/deploy-backend.yml']
+  workflow_dispatch:
 
 concurrency:
   group: deploy-backend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+ENV UV_CACHE_DIR=/tmp/.uv-cache
 
 # Copy dependency files first for caching
 COPY pyproject.toml uv.lock* ./


### PR DESCRIPTION
## Summary

Google's serverless runtime base image runs as a non-root user, so uv can't write to `/root/.cache/uv`. Set `UV_CACHE_DIR=/tmp/.uv-cache` to use a writable location.