### PR TITLE
fix: Dockerfile permissions for Google non-root base image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /app
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 ENV UV_CACHE_DIR=/tmp/.uv-cache
+ENV UV_PYTHON_INSTALL_DIR=/tmp/.uv-python
+ENV UV_PYTHON=python3
 
 # Copy dependency files first for caching
 COPY pyproject.toml uv.lock* ./


### PR DESCRIPTION
## Summary

Google's serverless base image runs as non-root and can't access `/root/`. Set:
- `UV_CACHE_DIR=/tmp/.uv-cache` 
- `UV_PYTHON_INSTALL_DIR=/tmp/.uv-python`
- `UV_PYTHON=python3` (use system Python from base image)