### PR TITLE
fix: Docker container startup and deploy env vars

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -65,4 +65,4 @@ jobs:
             --max-instances 3 \
             --timeout 60 \
             --cpu-boost \
-            --set-env-vars "CARTWISE_ENV=production"
+            --update-env-vars "CARTWISE_ENV=production"

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+.venv
+__pycache__
+*.pyc
+.secrets.toml
+.pytest_cache
+.coverage
+coverage.xml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,7 +11,8 @@ RUN uv sync --frozen --no-dev
 COPY . .
 
 ENV PYTHONUNBUFFERED=1
+ENV PATH="/app/.venv/bin:$PATH"
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "exec uv run uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]


### PR DESCRIPTION
## Summary
- Add `.dockerignore` to exclude local `.venv` from build context — previously `COPY . .` overwrote the Linux venv with the macOS one, causing `uv run` to reinstall 101 packages at runtime (blowing past 512 MiB and timing out)
- Set `PATH` to `.venv/bin` and invoke `uvicorn` directly instead of through `uv run` — no runtime package management needed
- Change deploy workflow from `--set-env-vars` (replaces all) to `--update-env-vars` (merges) — the previous behavior wiped all Cloud Run env vars on every deploy

## Test plan
- [x] Built and tested locally: container starts in ~2s, responds on `/healthz`, uses 267 MiB at idle
- [x] Deploy workflow triggers and Cloud Run revision comes up healthy