### PR TITLE
fix: rename /healthz to /health for Cloud Run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         run: cd backend && uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 &
 
       - name: Wait for backend
-        run: timeout 30 bash -c 'until curl -sf http://localhost:8000/healthz; do sleep 1; done'
+        run: timeout 30 bash -c 'until curl -sf http://localhost:8000/health; do sleep 1; done'
 
       - name: Generate fresh OpenAPI types
         run: bunx openapi-typescript@7.13.0 http://localhost:8000/openapi.json -o /tmp/schema.d.ts

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -65,4 +65,4 @@ jobs:
             --max-instances 3 \
             --timeout 60 \
             --cpu-boost \
-            --set-env-vars "CARTWISE_ENV=production"
+            --update-env-vars "CARTWISE_ENV=production"

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+.venv
+__pycache__
+*.pyc
+.secrets.toml
+.pytest_cache
+.coverage
+coverage.xml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,7 +11,8 @@ RUN uv sync --frozen --no-dev
 COPY . .
 
 ENV PYTHONUNBUFFERED=1
+ENV PATH="/app/.venv/bin:$PATH"
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "exec uv run uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,6 +44,6 @@ app.include_router(meal_plans.router, prefix="/api/v1")
 app.include_router(orders.router, prefix="/api/v1")
 
 
-@app.get("/healthz")
-async def healthz():
+@app.get("/health")
+async def health():
     return {"status": "ok"}

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -101,12 +101,12 @@ async def _create_menu_item(client: AsyncClient, token: str, name: str, body: st
 
 
 # ================================================================
-# Tests — healthz
+# Tests — health
 # ================================================================
 
 
-async def test_healthz(client: AsyncClient):
-    resp = await client.get("/healthz")
+async def test_health(client: AsyncClient):
+    resp = await client.get("/health")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
 

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -7,8 +7,8 @@ from httpx import AsyncClient
 from app.models.user import User
 
 
-async def test_healthz(client: AsyncClient):
-    response = await client.get("/healthz")
+async def test_health(client: AsyncClient):
+    response = await client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 

--- a/ui/lib/api/schema.d.ts
+++ b/ui/lib/api/schema.d.ts
@@ -396,15 +396,15 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/healthz": {
+    "/health": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Healthz */
-        get: operations["healthz_healthz_get"];
+        /** Health */
+        get: operations["health_health_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1450,7 +1450,7 @@ export interface operations {
             };
         };
     };
-    healthz_healthz_get: {
+    health_health_get: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## Summary
- Cloud Run intercepts `/healthz` at the infrastructure layer — requests never reach the container
- Renamed to `/health` which works correctly
- Updated CI workflow, tests, and OpenAPI schema

## Test plan
- [x] Local: `curl http://localhost:8000/health` returns `{"status":"ok"}`
- [ ] Production: `curl https://cartwise-backend-x5fqzyd4qa-uc.a.run.app/health` works after deploy