### PR TITLE
fix(vault): use vault API functions instead of raw table UPDATE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         run: cd backend && uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 &
 
       - name: Wait for backend
-        run: timeout 30 bash -c 'until curl -sf http://localhost:8000/healthz; do sleep 1; done'
+        run: timeout 30 bash -c 'until curl -sf http://localhost:8000/health; do sleep 1; done'
 
       - name: Generate fresh OpenAPI types
         run: bunx openapi-typescript@7.13.0 http://localhost:8000/openapi.json -o /tmp/schema.d.ts

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -65,4 +65,4 @@ jobs:
             --max-instances 3 \
             --timeout 60 \
             --cpu-boost \
-            --set-env-vars "CARTWISE_ENV=production"
+            --update-env-vars "CARTWISE_ENV=production"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Grocery cost splitting with meal planning — monorepo.
 
 ```
 backend/   — FastAPI API server (Python)
-ui/        — Frontend (Next.js + React + Tailwind) — coming soon
+ui/        — Frontend (Next.js + React + Tailwind)
 ```
 
 ## Orientation
@@ -14,3 +14,24 @@ ui/        — Frontend (Next.js + React + Tailwind) — coming soon
 - @backend/CLAUDE.md — backend-specific orientation, key files, commands
 - @backend/docs/architecture.md — data flow, DB schema, auth, AI layer
 - @CONTRIBUTING.md — prerequisites, quick start, workflow
+
+## Important Principles
+
+- **Never justify cutting corners (security, architecture, best practices) by citing project size, user count, or cost or any excuse. Do things the right way.
+- **Secrets are secrets.** Store them in proper secret management (Secret Manager, or some XYZ vault), not plaintext env vars. This applies regardless of who has access today.
+- **Each system owns only its secrets.** GitHub Secrets hold only what CI needs. Cloud Run / Secret Manager hold only what runtime needs. No duplication.
+- **Never run migrations manually against production.** Migrations run via GitHub Actions on deploy. Only run locally against dev/test databases.
+- **Never run database mutating queries manually against production.** Only run locally against dev/test databases. Or unless user approves it and knows about it.
+- **Non-secret config belongs in code.** If a value isn't secret, it goes in `settings.toml` (version-controlled, reviewable). Env vars are only for secrets and deploy-specific overrides (like CORS origins that depend on the Vercel URL).
+
+## Deployment
+
+| Component | Platform | Deploy trigger |
+|-----------|----------|----------------|
+| Backend | Google Cloud Run | Push to `main` (GitHub Actions) |
+| Frontend | Vercel | Push to `main` (auto) |
+| Database + Auth + Storage | Supabase | Managed |
+
+- Backend URL: `https://cartwise-backend-x5fqzyd4qa-uc.a.run.app`
+- Frontend URL: `https://cartwise-amber.vercel.app`
+- Supabase project: `zwtqhrwsbmbuhwqcvrmj`

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+.venv
+__pycache__
+*.pyc
+.secrets.toml
+.pytest_cache
+.coverage
+coverage.xml

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -48,3 +48,7 @@ CARTWISE_ENV=development uv run alembic upgrade head
 - Config via Dynaconf: `settings.toml` (committed) + `.secrets.toml` (gitignored).
 - Conventional Commits enforced by pre-commit hook.
 - Tests: pytest + httpx + pytest-asyncio. Mock LLM via `app.ai.client.generate`.
+- **Never run migrations manually against production.** Migrations run automatically via GitHub Actions on deploy. Only run locally against dev/test databases.
+- **Never run mutating database queries against production.** No manual INSERTs, UPDATEs, GRANTs, etc. All schema and permission changes go through Alembic migrations. Read-only queries are OK for debugging (with user approval).
+- **Secrets go in GCP Secret Manager**, not plaintext Cloud Run env vars. Cloud Run env vars are only for non-secret config overrides.
+- **Keep container startup minimal.** No migrations, no heavy init. Just start uvicorn.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,7 +11,8 @@ RUN uv sync --frozen --no-dev
 COPY . .
 
 ENV PYTHONUNBUFFERED=1
+ENV PATH="/app/.venv/bin:$PATH"
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "exec uv run uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,6 +44,6 @@ app.include_router(meal_plans.router, prefix="/api/v1")
 app.include_router(orders.router, prefix="/api/v1")
 
 
-@app.get("/healthz")
-async def healthz():
+@app.get("/health")
+async def health():
     return {"status": "ok"}

--- a/backend/app/services/vault.py
+++ b/backend/app/services/vault.py
@@ -21,10 +21,11 @@ async def store_secret(
         text("SELECT id FROM vault.secrets WHERE name = :name"),
         {"name": name},
     )
-    if existing.scalar_one_or_none():
+    row_id = existing.scalar_one_or_none()
+    if row_id:
         await session.execute(
-            text("UPDATE vault.secrets SET secret = :secret WHERE name = :name"),
-            {"name": name, "secret": secret},
+            text("SELECT vault.update_secret(:id, :secret)"),
+            {"id": row_id, "secret": secret},
         )
     else:
         await session.execute(

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -101,12 +101,12 @@ async def _create_menu_item(client: AsyncClient, token: str, name: str, body: st
 
 
 # ================================================================
-# Tests — healthz
+# Tests — health
 # ================================================================
 
 
-async def test_healthz(client: AsyncClient):
-    resp = await client.get("/healthz")
+async def test_health(client: AsyncClient):
+    resp = await client.get("/health")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
 

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -7,8 +7,8 @@ from httpx import AsyncClient
 from app.models.user import User
 
 
-async def test_healthz(client: AsyncClient):
-    response = await client.get("/healthz")
+async def test_health(client: AsyncClient):
+    response = await client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 

--- a/ui/lib/api/schema.d.ts
+++ b/ui/lib/api/schema.d.ts
@@ -396,15 +396,15 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/healthz": {
+    "/health": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Healthz */
-        get: operations["healthz_healthz_get"];
+        /** Health */
+        get: operations["health_health_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1450,7 +1450,7 @@ export interface operations {
             };
         };
     };
-    healthz_healthz_get: {
+    health_health_get: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## Summary

- Fixes Splitwise token storage failing in production with `permission denied for table secrets`
- The `postgres` role in Supabase has EXECUTE on `vault.create_secret()` / `vault.update_secret()` but not INSERT/UPDATE on the raw table
- The create path was already using the function correctly; the update path was doing a raw `UPDATE` — fixed to use `vault.update_secret(id, secret)`
- Adds deployment principles and operational rules to CLAUDE.md files

## Test plan

- [x] Merge to main → GitHub Actions deploys to Cloud Run
- [x] Login on https://cartwise-amber.vercel.app → authorize Splitwise → token stored successfully
- [x] Re-authorize (update path) also works