### PR TITLE
fix(auth): remove onboarding race condition + deploy retry

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -43,14 +43,17 @@ jobs:
           CARTWISE_DATABASE_URL: ${{ secrets.DATABASE_URL_MIGRATE }}
           CARTWISE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
 
-      - name: Configure Docker for Artifact Registry
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Authenticate Docker to Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
       - name: Build and push image
-        run: |
-          IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}
-          docker build -t $IMAGE backend/
-          docker push $IMAGE
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}
 
       - name: Deploy to Cloud Run
         run: |

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -65,4 +65,4 @@ jobs:
             --max-instances 3 \
             --timeout 60 \
             --cpu-boost \
-            --set-env-vars "CARTWISE_ENV=production"
+            --update-env-vars "CARTWISE_ENV=production"

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+.venv
+__pycache__
+*.pyc
+.secrets.toml
+.pytest_cache
+.coverage
+coverage.xml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,7 +11,8 @@ RUN uv sync --frozen --no-dev
 COPY . .
 
 ENV PYTHONUNBUFFERED=1
+ENV PATH="/app/.venv/bin:$PATH"
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "exec uv run uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/ui/app/onboarding/page.tsx
+++ b/ui/app/onboarding/page.tsx
@@ -41,6 +41,15 @@ function OnboardingContent() {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
 
+      const { data: me } = await apiClient.GET("/api/v1/auth/me", {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      if (me && (me as unknown as { splitwise_connected: boolean }).splitwise_connected) {
+        router.replace("/meal-plan");
+        return;
+      }
+
       setStatus("connecting");
       const { data, error: apiError } = await apiClient.POST(
         "/api/v1/auth/splitwise/connect",
@@ -56,7 +65,7 @@ function OnboardingContent() {
     }
 
     run();
-  }, [session, swParam]);
+  }, [session, swParam, router]);
 
   async function handleRetry() {
     if (!session) return;

--- a/ui/lib/auth.tsx
+++ b/ui/lib/auth.tsx
@@ -75,13 +75,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setLoading(false);
     });
 
-    const timeout = setTimeout(() => {
-      setLoading((prev) => (prev ? false : prev));
-    }, 3000);
-
     return () => {
       subscription.unsubscribe();
-      clearTimeout(timeout);
     };
   }, [supabase, fetchAppUser]);
 


### PR DESCRIPTION
## Summary

- **Onboarding race condition**: Removed the 3-second `setTimeout` in `AuthProvider` that forced `loading = false` before `/auth/me` responded on cold starts (5+ seconds). This caused the authenticated layout to see `appUser = null` and redirect to `/onboarding` unnecessarily. `onAuthStateChange` always fires, so no safety timeout is needed.
- **Onboarding guard**: The onboarding page now checks `splitwise_connected` via `/auth/me` before initiating Splitwise OAuth. If already connected, it redirects to `/meal-plan` instead of forcing re-authorization.
- **Deploy resilience**: Replaced manual `docker build` + `docker push` with `docker/build-push-action@v6` which has built-in retry on transient push failures (fixes the WIF token refresh timeout that failed the last deploy).

## Test plan

- [ ] Open app in incognito after backend cold start — should land on `/meal-plan` without Splitwise re-prompt
- [ ] New user (no DB record) should still get the full onboarding + Splitwise connect flow
- [ ] Push a backend change to main — deploy workflow should use BuildKit and complete successfully