### PR TITLE
fix(backend): httpx timeouts, temp file cleanup, BuildKit deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -46,17 +46,19 @@ jobs:
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
+      - uses: docker/setup-buildx-action@v3
+
       - name: Build and push image
-        run: |
-          IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}
-          docker build -t $IMAGE backend/
-          docker push $IMAGE
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}
 
       - name: Deploy to Cloud Run
         run: |
-          IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}
           gcloud run deploy ${{ env.SERVICE }} \
-            --image $IMAGE \
+            --image ${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }} \
             --region ${{ env.REGION }} \
             --allow-unauthenticated \
             --memory 512Mi \

--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -148,7 +148,12 @@ async def create_order(
 
     # Pipeline: extract → classify → correlate → split
     local_pdf = await asyncio.to_thread(download_to_temp, storage_path)
-    extracted = await asyncio.to_thread(extract, local_pdf)
+    try:
+        extracted = await asyncio.to_thread(extract, local_pdf)
+    finally:
+        from pathlib import Path
+
+        Path(local_pdf).unlink(missing_ok=True)
     classified = await classify(extracted)
 
     # Get only "item" category grocery items for correlation

--- a/backend/app/services/splitwise.py
+++ b/backend/app/services/splitwise.py
@@ -93,21 +93,21 @@ def _build_expense_payload(
 
 def get_current_user() -> dict:
     _check_enabled()
-    resp = httpx.get(f"{_base_url()}/get_current_user", headers=_headers())
+    resp = httpx.get(f"{_base_url()}/get_current_user", headers=_headers(), timeout=30)
     resp.raise_for_status()
     return resp.json()["user"]
 
 
 def get_friends() -> list[dict]:
     _check_enabled()
-    resp = httpx.get(f"{_base_url()}/get_friends", headers=_headers())
+    resp = httpx.get(f"{_base_url()}/get_friends", headers=_headers(), timeout=30)
     resp.raise_for_status()
     return resp.json()["friends"]
 
 
 def get_groups() -> list[dict]:
     _check_enabled()
-    resp = httpx.get(f"{_base_url()}/get_groups", headers=_headers())
+    resp = httpx.get(f"{_base_url()}/get_groups", headers=_headers(), timeout=30)
     resp.raise_for_status()
     return resp.json()["groups"]
 
@@ -168,7 +168,9 @@ async def create_expense_audited(
 
     # Step 2: Call Splitwise API
     try:
-        resp = httpx.post(f"{_base_url()}/create_expense", headers=_headers(token), json=payload)
+        resp = httpx.post(
+            f"{_base_url()}/create_expense", headers=_headers(token), json=payload, timeout=30
+        )
         resp.raise_for_status()
         data = resp.json()
 
@@ -216,7 +218,9 @@ async def delete_expense_audited(
 
     try:
         resp = httpx.post(
-            f"{_base_url()}/delete_expense/{splitwise_expense_id}", headers=_headers(token)
+            f"{_base_url()}/delete_expense/{splitwise_expense_id}",
+            headers=_headers(token),
+            timeout=30,
         )
         resp.raise_for_status()
         data = resp.json()

--- a/backend/app/services/splitwise.py
+++ b/backend/app/services/splitwise.py
@@ -21,6 +21,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.models.splitwise_audit import SplitwiseAuditLog
 
+_http = httpx.Client(timeout=30)
+
 
 def _base_url() -> str:
     url = settings.get("SPLITWISE_BASE_URL", "")
@@ -93,21 +95,21 @@ def _build_expense_payload(
 
 def get_current_user() -> dict:
     _check_enabled()
-    resp = httpx.get(f"{_base_url()}/get_current_user", headers=_headers(), timeout=30)
+    resp = _http.get(f"{_base_url()}/get_current_user", headers=_headers())
     resp.raise_for_status()
     return resp.json()["user"]
 
 
 def get_friends() -> list[dict]:
     _check_enabled()
-    resp = httpx.get(f"{_base_url()}/get_friends", headers=_headers(), timeout=30)
+    resp = _http.get(f"{_base_url()}/get_friends", headers=_headers())
     resp.raise_for_status()
     return resp.json()["friends"]
 
 
 def get_groups() -> list[dict]:
     _check_enabled()
-    resp = httpx.get(f"{_base_url()}/get_groups", headers=_headers(), timeout=30)
+    resp = _http.get(f"{_base_url()}/get_groups", headers=_headers())
     resp.raise_for_status()
     return resp.json()["groups"]
 
@@ -168,9 +170,7 @@ async def create_expense_audited(
 
     # Step 2: Call Splitwise API
     try:
-        resp = httpx.post(
-            f"{_base_url()}/create_expense", headers=_headers(token), json=payload, timeout=30
-        )
+        resp = _http.post(f"{_base_url()}/create_expense", headers=_headers(token), json=payload)
         resp.raise_for_status()
         data = resp.json()
 
@@ -217,10 +217,9 @@ async def delete_expense_audited(
     await session.refresh(audit)
 
     try:
-        resp = httpx.post(
+        resp = _http.post(
             f"{_base_url()}/delete_expense/{splitwise_expense_id}",
             headers=_headers(token),
-            timeout=30,
         )
         resp.raise_for_status()
         data = resp.json()


### PR DESCRIPTION
## Summary

- **httpx timeouts**: All Splitwise API calls in `splitwise.py` now have explicit `timeout=30` — without this, calls could hang indefinitely if Splitwise is slow or unresponsive
- **Temp file cleanup**: `orders.py` now cleans up the temp PDF file after extraction via `try/finally`, preventing disk leaks on long-running instances
- **BuildKit deploy**: Replaced manual `docker build` + `docker push` with `docker/build-push-action@v6` which uses BuildKit and has built-in retry for transient registry auth failures (previously caused deploy failures due to WIF token refresh timeouts)

## Test plan

- [x] `ruff check` + `ruff format --check` — all pass
- [x] Unit tests — 131 passed
- [ ] Deploy workflow succeeds on merge (BuildKit action)
- [ ] Splitwise connect flow still works (timeout doesn't break normal calls)