### PR TITLE
fix(ui): loading states, typography, profile UX improvements

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,12 +40,12 @@ if settings.DEBUG:
     from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.requests import Request
 
-    DEV_DELAY_SECONDS = 1.5
+    DEV_DELAY_MS = 1500
 
     class SlowMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request: Request, call_next):
-            if DEV_DELAY_SECONDS and request.url.path != "/health":
-                await asyncio.sleep(DEV_DELAY_SECONDS)
+            if DEV_DELAY_MS and request.url.path != "/health":
+                await asyncio.sleep(DEV_DELAY_MS / 1000)
             return await call_next(request)
 
     app.add_middleware(SlowMiddleware)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,23 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Dev-only: slow down API responses to test loading states
+if settings.DEBUG:
+    import asyncio
+
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.requests import Request
+
+    DEV_DELAY_SECONDS = 1.5
+
+    class SlowMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request: Request, call_next):
+            if DEV_DELAY_SECONDS and request.url.path != "/health":
+                await asyncio.sleep(DEV_DELAY_SECONDS)
+            return await call_next(request)
+
+    app.add_middleware(SlowMiddleware)
+
 # Error handlers
 register_error_handlers(app)
 

--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -62,7 +62,7 @@ export default function MealPlanEditPage() {
     );
   }, [menuItems, search]);
 
-  const dataReady = !menuItemsLoading && !mealPlanLoading;
+  const dataReady = !!appUser && !menuItemsLoading && !mealPlanLoading;
 
   function toggle(id: string) {
     const base = selected ?? initialIds;
@@ -137,7 +137,7 @@ export default function MealPlanEditPage() {
         )}
       </div>
 
-      <main className="flex-1">
+      <main className={`flex flex-1 flex-col ${!dataReady ? "items-center justify-center" : ""}`}>
         {mode === "select" ? (
           dataReady ? (
             <>
@@ -198,7 +198,7 @@ export default function MealPlanEditPage() {
             disabled={saving}
             className="flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:opacity-50"
           >
-            {saving ? "Saving..." : "Save"}
+            {saving ? <div className="size-6 animate-spin rounded-full border-[3px] border-white border-t-transparent" /> : "Save"}
           </button>
         )}
       </div>

--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -27,13 +27,15 @@ export default function MealPlanEditPage() {
   const { data: menuItems, isLoading: menuItemsLoading } = $api.useQuery(
     "get",
     "/api/v1/menu-items/",
-    { params: { query: { status: "active", created_by: appUser!.id } } },
+    { params: { query: { status: "active", created_by: appUser?.id ?? "" } } },
+    { enabled: !!appUser },
   );
 
   const { data: mealPlan, isLoading: mealPlanLoading } = $api.useQuery(
     "get",
     "/api/v1/meal-plans/{user_id}",
-    { params: { path: { user_id: appUser!.id } } },
+    { params: { path: { user_id: appUser?.id ?? "" } } },
+    { enabled: !!appUser },
   );
 
   const initialIds = useMemo(() => {

--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -10,6 +10,7 @@ import apiClient from "@/lib/api/client";
 import { TopBar } from "@/components/top-bar";
 import { MealPlanItem } from "@/components/meal-plan-item";
 import { Icon } from "@/components/icon";
+import { Spinner } from "@/components/spinner";
 
 const MealPlanReorder = dynamic(() => import("@/components/meal-plan-reorder"));
 
@@ -158,7 +159,7 @@ export default function MealPlanEditPage() {
                 </p>
               )}
             </>
-          ) : null
+          ) : <Spinner />
         ) : (
           orderedItems && (
             <MealPlanReorder

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -39,7 +39,7 @@ export default function MealPlanPage() {
       </div>
 
       <main
-        className={cn("flex-1", ready && !hasItems && "flex items-center justify-center")}
+        className={cn("flex-1", (!ready || !hasItems) && "flex items-center justify-center")}
       >
         {!ready ? <Spinner /> : !hasItems ? (
           <button

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -25,27 +25,7 @@ export default function MealPlanPage() {
 
   return (
     <div className="flex flex-1 flex-col">
-      <TopBar
-        rightAction={
-          appUser ? (
-            <button
-              onClick={() => router.push("/profile")}
-              aria-label="Profile"
-              className="flex h-full w-full items-center justify-center"
-            >
-              {appUser.avatar_url ? (
-                <img
-                  src={appUser.avatar_url}
-                  alt=""
-                  className="h-9 w-9 rounded-full object-cover"
-                />
-              ) : (
-                <Icon name="account_circle" size={36} />
-              )}
-            </button>
-          ) : undefined
-        }
-      />
+      <TopBar />
 
       <div className="flex items-stretch justify-between border-b border-black">
         <span className="flex items-center p-3 text-2xl font-bold tracking-label uppercase leading-6">

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -6,6 +6,7 @@ import { $api } from "@/lib/api/hooks";
 import { TopBar } from "@/components/top-bar";
 import { MealPlanItem } from "@/components/meal-plan-item";
 import { Icon } from "@/components/icon";
+import { Spinner } from "@/components/spinner";
 import { useRouter } from "next/navigation";
 
 export default function MealPlanPage() {
@@ -60,7 +61,7 @@ export default function MealPlanPage() {
       <main
         className={cn("flex-1", ready && !hasItems && "flex items-center justify-center")}
       >
-        {!ready ? null : !hasItems ? (
+        {!ready ? <Spinner /> : !hasItems ? (
           <button
             onClick={() => router.push("/meal-plan/edit")}
             aria-label="Create meal plan"

--- a/ui/app/(authenticated)/profile/page.tsx
+++ b/ui/app/(authenticated)/profile/page.tsx
@@ -13,6 +13,7 @@ export default function ProfilePage() {
   const router = useRouter();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
   const [error, setError] = useState("");
 
   if (!appUser) return null;
@@ -39,30 +40,29 @@ export default function ProfilePage() {
     <div className="flex flex-1 flex-col">
       <TopBar showBack onBack={() => router.push("/meal-plan")} />
 
-      <div className="flex h-12 items-center border-b border-black gap-3">
-        <div className="flex w-12 shrink-0 items-center justify-center">
-          {appUser.avatar_url ? (
-            <img
-              src={appUser.avatar_url}
-              alt=""
-              className="h-9 w-9 rounded-full object-cover"
-            />
-          ) : (
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-black text-white">
-              <Icon name="person" size={20} />
-            </div>
-          )}
-        </div>
-        <span className="text-2xl font-bold tracking-label uppercase leading-6">
+      <div className="flex h-12 items-center border-b border-black">
+        <span className="flex-1 p-3 text-2xl font-bold tracking-label uppercase leading-6">
           {appUser.name}
         </span>
+        <button
+          onClick={async () => {
+            setSigningOut(true);
+            await signOut();
+            window.location.href = "/login";
+          }}
+          disabled={signingOut}
+          aria-label="Sign out"
+          className="flex h-12 w-12 shrink-0 items-center justify-center bg-black"
+        >
+          {signingOut ? <div className="size-5 animate-spin rounded-full border-[3px] border-white border-t-transparent" /> : <Icon name="logout" size={24} className="text-white translate-x-px" />}
+        </button>
       </div>
 
       <main className="flex flex-1 flex-col p-3">
         <p className="text-sm text-gray-600">{appUser.email}</p>
 
         <div className="flex items-center gap-2 mt-3">
-          <Icon name={appUser.splitwise_connected ? "check_circle" : "cancel"} size={20} />
+          <Icon name={appUser.splitwise_connected ? "check_circle" : "cancel"} size={20} className={appUser.splitwise_connected ? "text-green-600" : ""} />
           <span className="text-sm tracking-wider">
             {appUser.splitwise_connected ? "Splitwise connected" : "Splitwise not connected"}
           </span>
@@ -74,18 +74,9 @@ export default function ProfilePage() {
 
         <div className="mt-auto flex flex-col gap-3">
           <button
-            onClick={async () => {
-              await signOut();
-              window.location.href = "/login";
-            }}
-            className="flex items-center justify-center border border-black p-3 text-base font-bold tracking-label uppercase"
-          >
-            Sign Out
-          </button>
-
-          <button
             onClick={() => setShowDeleteDialog(true)}
-            className="flex items-center justify-center border border-black p-3 text-base font-bold tracking-label uppercase text-red-600"
+            disabled={signingOut}
+            className="flex items-center justify-center border border-black p-3 text-base font-bold tracking-label uppercase text-red-600 h-12"
           >
             Delete Account
           </button>

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -2,6 +2,8 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
+@plugin "@tailwindcss/typography";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -10,6 +10,7 @@
         "@serwist/next": "^9.5.7",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.103.0",
+        "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.99.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
@@ -344,6 +345,8 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA=="],
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.2", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "postcss": "^8.5.6", "tailwindcss": "4.2.2" } }, "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ=="],
+
+    "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.99.0", "", {}, "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ=="],
 
@@ -1237,7 +1240,7 @@
 
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
-    "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
+    "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
@@ -1668,6 +1671,8 @@
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "shadcn/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "shadcn/postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/ui/components/confirm-delete-dialog.tsx
+++ b/ui/components/confirm-delete-dialog.tsx
@@ -45,9 +45,9 @@ export function ConfirmDeleteDialog({ onConfirm, onCancel, loading }: ConfirmDel
           <button
             onClick={onConfirm}
             disabled={input !== "delete" || loading}
-            className="flex-1 bg-black p-3 text-base font-bold tracking-label uppercase text-white disabled:opacity-30"
+            className="flex-1 flex items-center justify-center bg-black p-3 text-base font-bold tracking-label uppercase text-white disabled:opacity-30"
           >
-            {loading ? "Deleting..." : "Delete"}
+            {loading ? <div className="size-5 animate-spin rounded-full border-[3px] border-white border-t-transparent" /> : "Delete"}
           </button>
         </div>
       </div>

--- a/ui/components/menu-item-page.tsx
+++ b/ui/components/menu-item-page.tsx
@@ -54,7 +54,8 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
   const { data: mealPlan } = $api.useQuery(
     "get",
     "/api/v1/meal-plans/{user_id}",
-    { params: { path: { user_id: appUser!.id } } },
+    { params: { path: { user_id: appUser?.id ?? "" } } },
+    { enabled: !!appUser },
   );
 
   const inPlan = mealPlan?.items.some((i) => i.menu_item.id === itemId) ?? false;
@@ -370,7 +371,7 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
             className="flex-1 w-full resize-none bg-transparent text-base font-medium leading-6 outline-none placeholder:text-gray-300"
           />
         ) : (
-          <article className="prose prose-sm max-w-none font-mono">
+          <article className="prose prose-sm max-w-none">
             <Markdown>{body || "*No content yet*"}</Markdown>
           </article>
         )}

--- a/ui/components/menu-item-page.tsx
+++ b/ui/components/menu-item-page.tsx
@@ -10,6 +10,7 @@ import { $api } from "@/lib/api/hooks";
 import apiClient from "@/lib/api/client";
 import { TopBar } from "@/components/top-bar";
 import { Icon } from "@/components/icon";
+import { Spinner } from "@/components/spinner";
 
 const Markdown = dynamic(() => import("react-markdown"));
 
@@ -276,6 +277,17 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
   // Show edit button only in view mode for existing items
   const showEditButton = !isNew && !editing;
 
+  if (!isNew && !item) {
+    return (
+      <div className="flex flex-1 flex-col">
+        <TopBar showBack onBack={handleBack} />
+        <main className="flex flex-1 items-center justify-center">
+          <Spinner />
+        </main>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-1 flex-col [overflow-anchor:none]">
       {/* TopBar — scrolls away (not sticky). The observer watches this
@@ -384,7 +396,7 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
             disabled={saving || !name.trim()}
             className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:opacity-30"
           >
-            {saving ? "Saving..." : "Save"}
+            {saving ? <div className="size-6 animate-spin rounded-full border-[3px] border-white border-t-transparent" /> : "Save"}
           </button>
       )}
 

--- a/ui/components/spinner.tsx
+++ b/ui/components/spinner.tsx
@@ -1,0 +1,7 @@
+export function Spinner() {
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <div className="size-6 animate-spin motion-reduce:animate-none rounded-full border-2 border-black border-t-transparent" />
+    </div>
+  );
+}

--- a/ui/components/spinner.tsx
+++ b/ui/components/spinner.tsx
@@ -1,7 +1,7 @@
 export function Spinner() {
   return (
-    <div className="flex flex-1 items-center justify-center">
-      <div className="size-6 animate-spin motion-reduce:animate-none rounded-full border-2 border-black border-t-transparent" />
+    <div className="flex h-14 w-14 items-center justify-center bg-black">
+      <div className="size-6 animate-spin motion-reduce:animate-none rounded-full border-[3px] border-white border-t-transparent" />
     </div>
   );
 }

--- a/ui/components/top-bar.tsx
+++ b/ui/components/top-bar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth";
 import { Icon } from "@/components/icon";
 
 interface TopBarProps {
@@ -11,6 +12,25 @@ interface TopBarProps {
 
 export function TopBar({ showBack = false, onBack, rightAction }: TopBarProps) {
   const router = useRouter();
+  const { appUser } = useAuth();
+
+  const defaultRight = appUser ? (
+    <button
+      onClick={() => router.push("/profile")}
+      aria-label="Profile"
+      className="flex h-full w-full items-center justify-center"
+    >
+      {appUser.avatar_url ? (
+        <img
+          src={appUser.avatar_url}
+          alt=""
+          className="h-9 w-9 rounded-full object-cover"
+        />
+      ) : (
+        <Icon name="account_circle" size={36} />
+      )}
+    </button>
+  ) : undefined;
 
   return (
     <header className="flex items-stretch justify-between border-b border-black">
@@ -30,7 +50,7 @@ export function TopBar({ showBack = false, onBack, rightAction }: TopBarProps) {
         <img src="/logo-pizza.avif" alt="" width={36} height={36} className="object-contain" />
       </div>
 
-      <div className="w-12 shrink-0 flex items-stretch">{rightAction}</div>
+      <div className="w-12 shrink-0 flex items-stretch">{rightAction ?? defaultRight}</div>
     </header>
   );
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,6 +15,7 @@
     "@serwist/next": "^9.5.7",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.0",
+    "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.99.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",


### PR DESCRIPTION
## Summary
- Add `@tailwindcss/typography` for proper markdown rendering in menu item view
- Fix null crash on page reload (guard queries with `enabled: !!appUser`)
- Add centered loading spinners (black square, white spinner) to meal-plan, meal-plan/edit, and menu-item pages
- Show profile avatar in TopBar globally (not just home page)
- Profile page: move sign-out to name bar as icon button, green Splitwise check
- Replace "Saving..."/"Deleting..." text with spinners
- Remove dead `LogoutButton` component
- Dev-only `SlowMiddleware` for testing loading states (`DEV_DELAY_SECONDS`)

## Test plan
- [ ] Reload `/meal-plan` — spinner shows, then content
- [ ] Reload `/meal-plan/edit` — spinner shows, no "No menu items found" flash
- [ ] Reload `/menu-items/[id]` — spinner shows, then item detail
- [ ] Profile: sign-out icon in name bar, spinner on click, redirects to login
- [ ] Menu item view: markdown renders with headings, bullet lists, etc.
- [ ] Profile avatar visible in TopBar on all authenticated pages