### PR TITLE
refactor(ui): server-side auth routing via proxy cookie

### DIFF
--- a/ui/app/(authenticated)/invoice/[id]/page.tsx
+++ b/ui/app/(authenticated)/invoice/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useCallback } from "react";
 import { notFound, useParams, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
-import { useAuth } from "@/lib/auth";
+import { useRequiredAuth } from "@/lib/auth";
 import { $api } from "@/lib/api/hooks";
 import apiClient from "@/lib/api/client";
 import { TopBar } from "@/components/top-bar";
@@ -22,7 +22,7 @@ export default function SplitAnalysisPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { appUser } = useAuth();
+  const { appUser } = useRequiredAuth();
 
   const [mode, setMode] = useState<"view" | "edit">("view");
   const [submitting, setSubmitting] = useState(false);
@@ -49,8 +49,8 @@ export default function SplitAnalysisPage() {
     () =>
       (order?.participants ?? [])
         .map((p) => ({ id: p.user_id, name: userMap.get(p.user_id) ?? p.user_id }))
-        .filter((u) => u.id !== appUser?.id)
-        .concat(appUser ? [{ id: appUser.id, name: appUser.name }] : []),
+        .filter((u) => u.id !== appUser.id)
+        .concat([{ id: appUser.id, name: appUser.name }]),
     [order, userMap, appUser],
   );
 

--- a/ui/app/(authenticated)/invoice/page.tsx
+++ b/ui/app/(authenticated)/invoice/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useState, useRef, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useAuth } from "@/lib/auth";
+import { useRequiredAuth } from "@/lib/auth";
 import { $api } from "@/lib/api/hooks";
 import { TopBar } from "@/components/top-bar";
 import { ChipInput, type ChipInputHandle } from "@/components/chip-input";
@@ -20,7 +20,7 @@ export default function InvoiceSetupPage() {
 }
 
 function InvoiceSetupContent() {
-  const { appUser, session } = useAuth();
+  const { appUser, session } = useRequiredAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
   const fileRef = useRef<HTMLInputElement>(null);
@@ -34,7 +34,7 @@ function InvoiceSetupContent() {
 
   const { data: users } = $api.useQuery("get", "/api/v1/users/");
   const otherUsers = (users ?? [])
-    .filter((u) => u.id !== appUser?.id)
+    .filter((u) => u.id !== appUser.id)
     .map((u) => ({ id: u.id, name: u.name }));
 
   // Pick up shared file from Web Share Target (cached by service worker)
@@ -52,11 +52,11 @@ function InvoiceSetupContent() {
   }, [searchParams]);
 
   async function handleAnalyse() {
-    if (!file || !session?.access_token || !appUser || selectedOthers.length === 0) return;
+    if (!file || !session?.access_token || selectedOthers.length === 0) return;
     setSubmitting(true);
 
     try {
-      const participantIds = [appUser!.id, ...selectedOthers];
+      const participantIds = [appUser.id, ...selectedOthers];
       const formData = new FormData();
       formData.append("file", file);
       formData.append("participant_ids", JSON.stringify(participantIds));

--- a/ui/app/(authenticated)/layout.tsx
+++ b/ui/app/(authenticated)/layout.tsx
@@ -1,9 +1,38 @@
-export const dynamic = "force-dynamic";
+"use client";
+
+import { useAuth } from "@/lib/auth";
+import { Spinner } from "@/components/spinner";
 
 export default function AuthenticatedLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const { appUser, loading, error, refreshAppUser } = useAuth();
+
+  if (loading || (!appUser && !error)) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error || !appUser) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 p-3">
+        <p className="text-xs text-red-600 tracking-wider">
+          Something went wrong.
+        </p>
+        <button
+          onClick={refreshAppUser}
+          className="border-2 border-black px-6 py-3 text-base font-bold tracking-label uppercase"
+        >
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
   return <div className="flex flex-1 flex-col">{children}</div>;
 }

--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
-import { useAuth } from "@/lib/auth";
+import { useRequiredAuth } from "@/lib/auth";
 import { $api } from "@/lib/api/hooks";
 import apiClient from "@/lib/api/client";
 import { TopBar } from "@/components/top-bar";
@@ -17,7 +17,7 @@ const MealPlanReorder = dynamic(() => import("@/components/meal-plan-reorder"));
 type Mode = "select" | "reorder";
 
 export default function MealPlanEditPage() {
-  const { appUser } = useAuth();
+  const { appUser } = useRequiredAuth();
   const router = useRouter();
   const queryClient = useQueryClient();
   const [mode, setMode] = useState<Mode>("select");
@@ -28,15 +28,13 @@ export default function MealPlanEditPage() {
   const { data: menuItems, isLoading: menuItemsLoading } = $api.useQuery(
     "get",
     "/api/v1/menu-items/",
-    { params: { query: { status: "active", created_by: appUser?.id ?? "" } } },
-    { enabled: !!appUser },
+    { params: { query: { status: "active", created_by: appUser.id } } },
   );
 
   const { data: mealPlan, isLoading: mealPlanLoading } = $api.useQuery(
     "get",
     "/api/v1/meal-plans/{user_id}",
-    { params: { path: { user_id: appUser?.id ?? "" } } },
-    { enabled: !!appUser },
+    { params: { path: { user_id: appUser.id } } },
   );
 
   const initialIds = useMemo(() => {
@@ -62,7 +60,7 @@ export default function MealPlanEditPage() {
     );
   }, [menuItems, search]);
 
-  const dataReady = !!appUser && !menuItemsLoading && !mealPlanLoading;
+  const dataReady = !menuItemsLoading && !mealPlanLoading;
 
   function toggle(id: string) {
     const base = selected ?? initialIds;
@@ -94,7 +92,7 @@ export default function MealPlanEditPage() {
     const { error: apiError } = await apiClient.PUT(
       "/api/v1/meal-plans/{user_id}",
       {
-        params: { path: { user_id: appUser!.id } },
+        params: { path: { user_id: appUser.id } },
         body: { menu_item_ids: orderedItems.map((i) => i.id) },
       },
     );

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useAuth } from "@/lib/auth";
+import { useRequiredAuth } from "@/lib/auth";
 import { cn } from "@/lib/utils";
 import { $api } from "@/lib/api/hooks";
 import { TopBar } from "@/components/top-bar";
@@ -10,18 +10,18 @@ import { Spinner } from "@/components/spinner";
 import { useRouter } from "next/navigation";
 
 export default function MealPlanPage() {
-  const { appUser } = useAuth();
+  const { appUser } = useRequiredAuth();
   const router = useRouter();
 
   const { data: mealPlan, isLoading } = $api.useQuery(
     "get",
     "/api/v1/meal-plans/{user_id}",
-    { params: { path: { user_id: appUser?.id ?? "" } }, enabled: !!appUser },
+    { params: { path: { user_id: appUser.id } } },
   );
 
   const items = mealPlan?.items ?? [];
   const hasItems = items.length > 0;
-  const ready = !!appUser && !isLoading;
+  const ready = !isLoading;
 
   return (
     <div className="flex flex-1 flex-col">

--- a/ui/app/(authenticated)/profile/page.tsx
+++ b/ui/app/(authenticated)/profile/page.tsx
@@ -2,21 +2,19 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { useAuth } from "@/lib/auth";
+import { useRequiredAuth } from "@/lib/auth";
 import { TopBar } from "@/components/top-bar";
 import { Icon } from "@/components/icon";
 import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog";
 import apiClient from "@/lib/api/client";
 
 export default function ProfilePage() {
-  const { appUser, signOut } = useAuth();
+  const { appUser, signOut } = useRequiredAuth();
   const router = useRouter();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
   const [error, setError] = useState("");
-
-  if (!appUser) return null;
 
   async function handleDelete() {
     setDeleting(true);

--- a/ui/app/auth/callback/route.ts
+++ b/ui/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { ONBOARDED_COOKIE, ONBOARDED_VALUE, ONBOARDED_COOKIE_OPTIONS } from "@/lib/cookies";
 
 function baseUrl(request: NextRequest): string {
   const proto = request.headers.get("x-forwarded-proto") || "http";
@@ -24,16 +25,24 @@ export async function GET(request: NextRequest) {
   }
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
-  const meResp = await fetch(`${apiUrl}/api/v1/auth/me`, {
-    headers: { Authorization: `Bearer ${sessionData.session.access_token}` },
-  });
+  let meResp: Response;
+  try {
+    meResp = await fetch(`${apiUrl}/api/v1/auth/me`, {
+      headers: { Authorization: `Bearer ${sessionData.session.access_token}` },
+    });
+  } catch {
+    return NextResponse.redirect(new URL("/login?error=backend", origin));
+  }
 
   if (meResp.ok) {
     const user = await meResp.json();
     if (user.splitwise_connected) {
-      return NextResponse.redirect(new URL("/", origin));
+      const response = NextResponse.redirect(new URL("/", origin));
+      response.cookies.set(ONBOARDED_COOKIE, ONBOARDED_VALUE, ONBOARDED_COOKIE_OPTIONS);
+      return response;
     }
+    return NextResponse.redirect(new URL("/onboarding", origin));
   }
 
-  return NextResponse.redirect(new URL("/onboarding", origin));
+  return NextResponse.redirect(new URL("/login?error=backend", origin));
 }

--- a/ui/app/auth/connect/splitwise/route.ts
+++ b/ui/app/auth/connect/splitwise/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { ONBOARDED_COOKIE, ONBOARDED_VALUE, ONBOARDED_COOKIE_OPTIONS } from "@/lib/cookies";
 
 function baseUrl(request: NextRequest): string {
   const proto = request.headers.get("x-forwarded-proto") || "http";
@@ -26,7 +27,9 @@ export async function GET(request: NextRequest) {
   });
 
   if (resp.ok) {
-    return NextResponse.redirect(new URL("/", origin));
+    const response = NextResponse.redirect(new URL("/", origin));
+    response.cookies.set(ONBOARDED_COOKIE, ONBOARDED_VALUE, ONBOARDED_COOKIE_OPTIONS);
+    return response;
   }
 
   return NextResponse.redirect(new URL("/onboarding?splitwise=error", origin));

--- a/ui/app/login/page.tsx
+++ b/ui/app/login/page.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { Icon } from "@/components/icon";
 
-export default function LoginPage() {
+function LoginContent() {
   const supabase = createClient();
-  const [error, setError] = useState("");
+  const searchParams = useSearchParams();
+  const errorParam = searchParams.get("error");
+  const [error, setError] = useState(
+    errorParam ? "Something went wrong. Please try again." : "",
+  );
 
   async function handleGoogleLogin() {
     setError("");
@@ -39,5 +44,13 @@ export default function LoginPage() {
         <p className="mt-4 text-xs text-red-600 tracking-wider">{error}</p>
       )}
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginContent />
+    </Suspense>
   );
 }

--- a/ui/components/menu-item-page.tsx
+++ b/ui/components/menu-item-page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
-import { useAuth } from "@/lib/auth";
+import { useRequiredAuth } from "@/lib/auth";
 import { cn } from "@/lib/utils";
 import { $api } from "@/lib/api/hooks";
 import apiClient from "@/lib/api/client";
@@ -19,7 +19,7 @@ interface MenuItemPageProps {
 }
 
 export function MenuItemPage({ itemId }: MenuItemPageProps) {
-  const { appUser } = useAuth();
+  const { appUser } = useRequiredAuth();
   const router = useRouter();
   const queryClient = useQueryClient();
   const isNew = !itemId;
@@ -55,8 +55,7 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
   const { data: mealPlan } = $api.useQuery(
     "get",
     "/api/v1/meal-plans/{user_id}",
-    { params: { path: { user_id: appUser?.id ?? "" } } },
-    { enabled: !!appUser },
+    { params: { path: { user_id: appUser.id } } },
   );
 
   const inPlan = mealPlan?.items.some((i) => i.menu_item.id === itemId) ?? false;
@@ -224,14 +223,14 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
                 {
                   params: {
                     path: {
-                      user_id: appUser!.id,
+                      user_id: appUser.id,
                       menu_item_id: itemId!,
                     },
                   },
                 },
               )
             : await apiClient.POST("/api/v1/meal-plans/{user_id}/items", {
-                params: { path: { user_id: appUser!.id } },
+                params: { path: { user_id: appUser.id } },
                 body: { menu_item_id: itemId! },
               });
           if (result.error) return;

--- a/ui/lib/api/client.ts
+++ b/ui/lib/api/client.ts
@@ -1,5 +1,6 @@
 import createFetchClient, { type Middleware } from "openapi-fetch";
 import type { paths } from "./schema";
+import { ONBOARDED_COOKIE } from "@/lib/cookies";
 
 let cachedToken: string | null = null;
 
@@ -20,6 +21,9 @@ const authMiddleware: Middleware = {
   async onResponse({ response }) {
     if (response.status === 401) {
       cachedToken = null;
+      if (typeof document !== "undefined") {
+        document.cookie = `${ONBOARDED_COOKIE}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+      }
     }
     return response;
   },

--- a/ui/lib/auth.tsx
+++ b/ui/lib/auth.tsx
@@ -11,6 +11,7 @@ import {
 import type { Session, User as SupabaseUser } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/client";
 import apiClient, { setAuthToken } from "@/lib/api/client";
+import { ONBOARDED_COOKIE } from "@/lib/cookies";
 
 interface AppUser {
   id: string;
@@ -26,6 +27,7 @@ interface AuthContextType {
   supabaseUser: SupabaseUser | null;
   appUser: AppUser | null;
   loading: boolean;
+  error: boolean;
   signOut: () => Promise<void>;
   refreshAppUser: () => Promise<void>;
 }
@@ -36,21 +38,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [appUser, setAppUser] = useState<AppUser | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   const supabase = useMemo(() => createClient(), []);
 
   const fetchAppUser = useCallback(async (accessToken: string) => {
     try {
-      const { data, error } = await apiClient.GET("/api/v1/auth/me", {
+      setError(false);
+      const { data, error: apiError } = await apiClient.GET("/api/v1/auth/me", {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
-      if (!error && data) {
+      if (!apiError && data) {
         setAppUser(data as unknown as AppUser);
       } else {
         setAppUser(null);
+        setError(true);
       }
     } catch {
       setAppUser(null);
+      setError(true);
     }
   }, []);
 
@@ -81,6 +87,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [supabase, fetchAppUser]);
 
   const signOut = useCallback(async () => {
+    document.cookie = `${ONBOARDED_COOKIE}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
     await supabase.auth.signOut();
     setAuthToken(null);
     setSession(null);
@@ -94,6 +101,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         supabaseUser: session?.user ?? null,
         appUser,
         loading,
+        error,
         signOut,
         refreshAppUser,
       }}
@@ -109,4 +117,12 @@ export function useAuth() {
     throw new Error("useAuth must be used within an AuthProvider");
   }
   return context;
+}
+
+export function useRequiredAuth() {
+  const context = useAuth();
+  if (!context.appUser) {
+    throw new Error("useRequiredAuth called outside authenticated layout");
+  }
+  return { ...context, appUser: context.appUser };
 }

--- a/ui/lib/cookies.ts
+++ b/ui/lib/cookies.ts
@@ -1,0 +1,10 @@
+export const ONBOARDED_COOKIE = "cartwise_onboarded";
+export const ONBOARDED_VALUE = "1";
+
+export const ONBOARDED_COOKIE_OPTIONS = {
+  path: "/",
+  httpOnly: false,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  maxAge: 60 * 60 * 24 * 365,
+};

--- a/ui/lib/supabase/proxy.ts
+++ b/ui/lib/supabase/proxy.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
+import { ONBOARDED_COOKIE } from "@/lib/cookies";
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
@@ -42,6 +43,18 @@ export async function updateSession(request: NextRequest) {
   }
 
   if (user && pathname === "/login") {
+    const url = request.nextUrl.clone();
+    url.pathname = "/";
+    return NextResponse.redirect(url);
+  }
+
+  if (user && !isPublicRoute && !request.cookies.get(ONBOARDED_COOKIE)) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/onboarding";
+    return NextResponse.redirect(url);
+  }
+
+  if (user && pathname.startsWith("/onboarding") && request.cookies.get(ONBOARDED_COOKIE)) {
     const url = request.nextUrl.clone();
     url.pathname = "/";
     return NextResponse.redirect(url);


### PR DESCRIPTION
## Summary

Moves the onboarding decision into the proxy (middleware) layer using a lightweight `cartwise_onboarded` cookie, eliminating client-side auth race conditions.

- **Proxy** now checks both Supabase session AND `cartwise_onboarded` cookie before allowing access to protected routes
- **Authenticated layout** blocks rendering until `appUser` loads (shows spinner), with error state + retry on failure
- **`useRequiredAuth()` hook** provides guaranteed non-null `appUser` to page components
- **All `enabled: !!appUser` guards removed** — no more boilerplate on every query
- Cookie set in auth callback + Splitwise callback, cleared on sign-out + 401

### Before
```
Page renders → auth fires (async) → appUser resolves → queries fire
                  ↑ crash if query fires before appUser exists
```

### After
```
Proxy guarantees auth+onboarding → Layout blocks until appUser → Page renders safely
```

## Verified

Tested locally (dev server + Chrome DevTools):

- No session → redirect to `/login`
- `/login?error=backend` → error message displays
- Google OAuth → cookie set → lands on `/meal-plan`
- Hard refresh on `/meal-plan` → content renders without redirect or crash
- Sign out → cookie cleared → redirected to `/login`
- Session present + cookie deleted → redirect to `/onboarding`
- TypeScript compiles clean, ESLint passes