### PR TITLE
fix(ui): disable Vercel deployments for entire/* branches

### DIFF
--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "entire/*": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `ui/vercel.json` with `git.deploymentEnabled` set to `false` for `entire/*` branches
- Prevents Vercel from triggering preview deployments for the Entire tool's checkpoint branch (`entire/checkpoints/v1`), which lacks the `ui/` root directory and causes build failures

## Verified

- [x] Root cause: Vercel's root directory validation fails before the ignore command runs
- [x] `git.deploymentEnabled` disables the deployment trigger entirely for matching branches