### PR TITLE
feat(ui): collapsible settings section + feedback button on profile

### DIFF
--- a/ui/app/(authenticated)/profile/page.tsx
+++ b/ui/app/(authenticated)/profile/page.tsx
@@ -70,15 +70,30 @@ export default function ProfilePage() {
           <p className="text-xs text-red-600 tracking-wider mt-3">{error}</p>
         )}
 
-        <div className="mt-auto flex flex-col gap-3">
-          <button
-            onClick={() => setShowDeleteDialog(true)}
-            disabled={signingOut}
-            className="flex items-center justify-center border border-black p-3 text-base font-bold tracking-label uppercase text-red-600 h-12"
-          >
-            Delete Account
-          </button>
-        </div>
+        <details className="mt-auto group">
+          <summary className="flex items-center gap-2 p-3 h-12 border border-black cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+            <Icon name="settings" size={20} />
+            <span className="text-base font-bold tracking-label uppercase">Settings</span>
+          </summary>
+          <div className="flex flex-col gap-3 mt-3">
+            <a
+              href="https://github.com/dostarora97/cartwise/issues/new/choose"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center gap-2 border border-black p-3 text-base font-bold tracking-label uppercase h-12"
+            >
+              <Icon name="feedback" size={20} />
+              Feedback
+            </a>
+            <button
+              onClick={() => setShowDeleteDialog(true)}
+              disabled={signingOut}
+              className="flex items-center justify-center border border-black p-3 text-base font-bold tracking-label uppercase text-red-600 h-12"
+            >
+              Delete Account
+            </button>
+          </div>
+        </details>
       </main>
 
       {showDeleteDialog && (


### PR DESCRIPTION
## Summary

- Move "Delete Account" into a collapsible `<details>` settings section at the bottom of the profile page
- Add a "Feedback" link inside the settings section that opens GitHub issues in a new tab
- Uses native HTML disclosure element — zero JS, accessible, matches the minimal design system

Closes #94, closes #95.

## Test plan

- [ ] Profile page: settings section collapsed by default with settings icon
- [ ] Clicking settings expands to show Feedback + Delete Account
- [ ] Feedback link opens `https://github.com/dostarora97/cartwise/issues/new/choose` in new tab
- [ ] Delete Account still triggers confirmation dialog
- [ ] Mobile viewport (375px) — no overflow