### PR TITLE
fix(ui): settings icon as plain heading, not bordered button

### DIFF
--- a/ui/app/(authenticated)/profile/page.tsx
+++ b/ui/app/(authenticated)/profile/page.tsx
@@ -70,12 +70,11 @@ export default function ProfilePage() {
           <p className="text-xs text-red-600 tracking-wider mt-3">{error}</p>
         )}
 
-        <details className="mt-auto group">
-          <summary className="flex items-center gap-2 p-3 h-12 border border-black cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+        <details className="mt-auto">
+          <summary className="flex items-center gap-2 h-12 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
             <Icon name="settings" size={20} />
-            <span className="text-base font-bold tracking-label uppercase">Settings</span>
           </summary>
-          <div className="flex flex-col gap-3 mt-3">
+          <div className="flex flex-col gap-3 pt-3">
             <a
               href="https://github.com/dostarora97/cartwise/issues/new/choose"
               target="_blank"


### PR DESCRIPTION
## Summary

- Remove border and "Settings" text from the disclosure toggle
- Gear icon acts as a plain heading/toggle
- Buttons (Feedback, Delete Account) are the bordered actionable items inside

Follow-up to #99 — the styling fixes didn't make it into the squash merge.

## Test plan

- [ ] Gear icon visible at bottom of profile, no border around it
- [ ] Clicking expands to show Feedback + Delete Account buttons
- [ ] Both buttons have their own borders