### PR TITLE
feat(backend): move Cloud Run to asia-south1 (Mumbai)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  REGION: us-central1
+  REGION: asia-south1
   SERVICE: cartwise-backend
   REPOSITORY: cartwise
 

--- a/ui/app/(authenticated)/profile/page.tsx
+++ b/ui/app/(authenticated)/profile/page.tsx
@@ -70,12 +70,11 @@ export default function ProfilePage() {
           <p className="text-xs text-red-600 tracking-wider mt-3">{error}</p>
         )}
 
-        <details className="mt-auto group">
-          <summary className="flex items-center gap-2 p-3 h-12 border border-black cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+        <details className="mt-auto">
+          <summary className="flex items-center gap-2 h-12 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
             <Icon name="settings" size={20} />
-            <span className="text-base font-bold tracking-label uppercase">Settings</span>
           </summary>
-          <div className="flex flex-col gap-3 mt-3">
+          <div className="flex flex-col gap-3 pt-3">
             <a
               href="https://github.com/dostarora97/cartwise/issues/new/choose"
               target="_blank"


### PR DESCRIPTION
## Summary

- Moves Cloud Run deployment from `us-central1` to `asia-south1` (Mumbai)
- Supabase DB is in AWS `ap-south-1` (Mumbai) — confirmed via IPv6 address resolution
- Eliminates cross-continent latency for user requests and backend→DB calls

## Prerequisites (before merging)

Create Artifact Registry repository in the new region:

```bash
gcloud artifacts repositories create cartwise \
  --repository-format=docker \
  --location=asia-south1 \
  --project=cartwise-1
```

## Post-deploy

1. Note the new Cloud Run URL (will be `https://cartwise-backend-<hash>-el.a.run.app`)
2. Update `NEXT_PUBLIC_API_URL` on Vercel with the new URL
3. Update `CLAUDE.md` backend URL reference

Closes #96