### PR TITLE
fix(backend): point dev FRONTEND_URL to localhost

### DIFF
--- a/backend/settings.toml
+++ b/backend/settings.toml
@@ -41,8 +41,8 @@ MOCK_SERVER_PORT = 8001
 [development]
 DEBUG = true
 SPLITWISE_ENABLED = true
-CORS_ORIGINS = ["https://lr602lw45l.taile1dca.ts.net", "http://localhost:3000"]
-FRONTEND_URL = "https://lr602lw45l.taile1dca.ts.net"
+CORS_ORIGINS = ["http://localhost:3000"]
+FRONTEND_URL = "http://localhost:3000"
 SESSION_SECRET_KEY = "dev-session-secret-not-for-production"
 
 [testing]


### PR DESCRIPTION
## Summary
- Remove Tailscale tunnel URL from `[development]` config in `settings.toml`
- `FRONTEND_URL` and `CORS_ORIGINS` now point to `http://localhost:3000` — the standard local dev setup
- Tailscale tunnel was a personal dev convenience that shouldn't be committed; it can be overridden via `CARTWISE_FRONTEND_URL` env var when needed

## Test plan
- [x] `CARTWISE_ENV=development uv run uvicorn app.main:app --reload --port 8000` starts cleanly
- [x] Splitwise OAuth redirect goes to `localhost:3000` (not the Tailscale URL)
- [x] Full local auth flow works: Google OAuth → local GoTrue → backend JWT validation → onboard → Splitwise mock → app renders