### PR TITLE
feat(ui): FAB shadows, clickable items, settings expandable, remove dead CSS

### DIFF
--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -130,7 +130,7 @@ export default function MealPlanEditPage() {
           />
         ) : (
           <span className="text-2xl font-bold tracking-label uppercase leading-6">
-            {orderedItems?.length ?? 0} items selected
+            {orderedItems?.length ?? 0} item(s) selected
           </span>
         )}
       </div>
@@ -172,7 +172,7 @@ export default function MealPlanEditPage() {
         <button
           onClick={() => router.push("/menu-items/new")}
           aria-label="New menu item"
-          className="fixed bottom-24 right-12 flex h-14 w-14 items-center justify-center bg-black text-white"
+          className="fixed bottom-24 right-12 flex h-14 w-14 items-center justify-center bg-black text-white shadow-[4px_4px_0_rgba(0,0,0,0.2)]"
         >
           <Icon name="add" size={24} />
         </button>

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -45,7 +45,7 @@ export default function MealPlanPage() {
           <button
             onClick={() => router.push("/meal-plan/edit")}
             aria-label="Create meal plan"
-            className="flex h-14 w-14 items-center justify-center bg-black text-white text-4xl"
+            className="flex h-14 w-14 items-center justify-center bg-black text-white text-4xl shadow-[4px_4px_0_rgba(0,0,0,0.2)]"
           >
             +
           </button>
@@ -69,7 +69,7 @@ export default function MealPlanPage() {
         <button
           onClick={() => router.push("/invoice")}
           aria-label="New expense"
-          className="fixed bottom-12 right-12 flex h-14 w-14 items-center justify-center bg-black text-white"
+          className="fixed bottom-12 right-12 flex h-14 w-14 items-center justify-center bg-black text-white shadow-[4px_4px_0_rgba(0,0,0,0.2)]"
         >
           <Icon name="receipt_long" size={24} />
         </button>

--- a/ui/app/(authenticated)/profile/page.tsx
+++ b/ui/app/(authenticated)/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useRequiredAuth } from "@/lib/auth";
 import { TopBar } from "@/components/top-bar";
@@ -15,6 +15,19 @@ export default function ProfilePage() {
   const [deleting, setDeleting] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
   const [error, setError] = useState("");
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const settingsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!settingsOpen) return;
+    function handleMouseDown(e: MouseEvent) {
+      if (settingsRef.current && !settingsRef.current.contains(e.target as Node)) {
+        setSettingsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [settingsOpen]);
 
   async function handleDelete() {
     setDeleting(true);
@@ -70,29 +83,37 @@ export default function ProfilePage() {
           <p className="text-xs text-red-600 tracking-wider mt-3">{error}</p>
         )}
 
-        <details className="mt-auto">
-          <summary className="flex items-center gap-2 h-12 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+        <div ref={settingsRef} className="mt-auto">
+          <button
+            onClick={() => setSettingsOpen(!settingsOpen)}
+            className="flex w-full items-center h-12 px-3 border border-black cursor-pointer"
+          >
             <Icon name="settings" size={20} />
-          </summary>
-          <div className="flex flex-col gap-3 pt-3">
-            <a
-              href="https://github.com/dostarora97/cartwise/issues/new/choose"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-center gap-2 border border-black p-3 text-base font-bold tracking-label uppercase h-12"
-            >
-              <Icon name="feedback" size={20} />
-              Feedback
-            </a>
-            <button
-              onClick={() => setShowDeleteDialog(true)}
-              disabled={signingOut}
-              className="flex items-center justify-center border border-black p-3 text-base font-bold tracking-label uppercase text-red-600 h-12"
-            >
-              Delete Account
-            </button>
-          </div>
-        </details>
+            <span className="ml-2 text-base font-bold tracking-label uppercase">Settings</span>
+            <Icon name={settingsOpen ? "expand_less" : "expand_more"} size={24} className="ml-auto" />
+          </button>
+          {settingsOpen && (
+            <div className="flex flex-col gap-3 p-3 border-x border-b border-black">
+              <a
+                href="https://github.com/dostarora97/cartwise/issues/new/choose"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center gap-2 bg-black text-white p-3 text-base font-bold tracking-label uppercase h-12"
+              >
+                <Icon name="open_in_new" size={20} />
+                Feedback
+              </a>
+              <button
+                onClick={() => setShowDeleteDialog(true)}
+                disabled={signingOut}
+                className="flex items-center justify-center gap-2 bg-black text-red-400 p-3 text-base font-bold tracking-label uppercase h-12"
+              >
+                <Icon name="delete" size={20} />
+                Delete Account
+              </button>
+            </div>
+          )}
+        </div>
       </main>
 
       {showDeleteDialog && (

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -1,6 +1,4 @@
 @import "tailwindcss";
-@import "tw-animate-css";
-@import "shadcn/tailwind.css";
 
 @plugin "@tailwindcss/typography";
 
@@ -14,111 +12,21 @@
   --tracking-heading: 0.3em;
   --tracking-label: 0.2em;
   --tracking-item: 0.15em;
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
-  --color-ring: var(--ring);
-  --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
   --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-primary: var(--primary);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
-  --color-card: var(--card);
-  --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) * 1.4);
-  --radius-2xl: calc(var(--radius) * 1.8);
-  --radius-3xl: calc(var(--radius) * 2.2);
-  --radius-4xl: calc(var(--radius) * 2.6);
+  --color-ring: var(--ring);
 }
 
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-}
-
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -23,7 +23,6 @@
         "react-markdown": "^10.1.0",
         "shadcn": "^4.2.0",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0",
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1549,8 +1548,6 @@
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 

--- a/ui/components/meal-plan-item.tsx
+++ b/ui/components/meal-plan-item.tsx
@@ -1,3 +1,5 @@
+import { Icon } from "@/components/icon";
+
 type Mode = "view" | "select";
 
 interface MealPlanItemProps {
@@ -38,9 +40,12 @@ export function MealPlanItem({
       {onTap ? (
         <button
           onClick={onTap}
-          className="flex-1 min-w-0 py-3 pr-3 text-left text-2xl font-medium tracking-item leading-6 truncate"
+          className="flex flex-1 items-center min-w-0 py-3 pr-3 text-left active:bg-gray-100"
         >
-          {name}
+          <span className="flex-1 min-w-0 text-2xl font-medium tracking-item leading-6 truncate">
+            {name}
+          </span>
+          <Icon name="chevron_right" size={20} className="shrink-0 text-gray-400 ml-2" />
         </button>
       ) : (
         <span className="flex-1 min-w-0 py-3 pr-3 text-2xl font-medium tracking-item leading-6 truncate">

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,8 +30,7 @@
     "react-dom": "19.2.4",
     "react-markdown": "^10.1.0",
     "shadcn": "^4.2.0",
-    "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- **#100**: Remove unused `tw-animate-css` package and `shadcn/tailwind.css` import — eliminates ~90 lines of dead CSS (animation keyframes, unused variables, dark theme tokens)
- **#88**: Add subtle gray offset shadow to all FABs, chevron_right icon on meal plan items for tap affordance, active press state
- **#105**: Replace bare settings icon with proper expandable row — bordered header with label + expand arrow, click-outside-closes, feedback/delete buttons now white/red on black

## Test plan
- [ ] `bun dev` starts without errors
- [ ] `/meal-plan` — items show chevron_right, invoice FAB has subtle shadow
- [ ] `/meal-plan/edit` — items show chevron_right, "+" FAB has shadow, reorder screen shows "N item(s) selected"
- [ ] `/profile` — settings row expands/collapses with arrow icon, click outside closes, buttons are white/red on black
- [ ] Empty meal plan state — "+" button has shadow
- [ ] Build CSS no longer contains `@keyframes enter`/`@keyframes exit` (dead weight removed)

Closes #88, closes #100, closes #105