### PR TITLE
fix(ui): new menu items appear immediately on back navigation

### DIFF
--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -29,6 +29,7 @@ export default function MealPlanEditPage() {
     "get",
     "/api/v1/menu-items/",
     { params: { query: { status: "active", created_by: appUser.id } } },
+    { staleTime: 0 },
   );
 
   const { data: mealPlan, isLoading: mealPlanLoading } = $api.useQuery(


### PR DESCRIPTION
## Summary
- Set `staleTime: 0` on the menu items query in `/meal-plan/edit` so it always refetches on mount
- Fixes: navigating back from `/menu-items/new` after saving now shows the newly created item immediately

**Root cause**: Global `staleTime: 60s` meant the cached menu item list was still considered "fresh" when the user navigated back, so React Query served stale data without the new item.

## Test plan
- [ ] Go to `/meal-plan/edit` → click "+" FAB → create and save a menu item → hit back → verify the new item appears in the list