### PR TITLE
fix(ui): don't force-capitalise menu item names

### DIFF
--- a/ui/components/menu-item-page.tsx
+++ b/ui/components/menu-item-page.tsx
@@ -309,13 +309,13 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
               suppressContentEditableWarning
               onKeyDown={(e) => { if (e.key === "Enter") e.preventDefault(); }}
               onInput={(e) => handleFormChange("name", e.currentTarget.textContent || "")}
-              className="flex-1 min-w-0 p-3 text-2xl font-bold tracking-heading uppercase leading-6 break-words outline-none empty:before:content-[attr(data-placeholder)] empty:before:text-gray-300"
+              className="flex-1 min-w-0 p-3 text-2xl font-bold tracking-heading leading-6 break-words outline-none empty:before:content-[attr(data-placeholder)] empty:before:text-gray-300"
               data-placeholder={isNew ? "Dish..." : "Item name"}
             />
           ) : (
             <h1
               ref={headingRef}
-              className="flex-1 min-w-0 p-3 text-2xl font-bold tracking-heading uppercase leading-6 break-words"
+              className="flex-1 min-w-0 p-3 text-2xl font-bold tracking-heading leading-6 break-words"
             >
               {name || "Untitled"}
             </h1>


### PR DESCRIPTION
## Summary
- Remove `uppercase` CSS class from menu item name in both view and edit modes
- Names now display as typed, consistent with the meal plan list

Closes #113

## Test plan
- [x] Create a menu item with mixed case (e.g., "Chicken Curry") — verify it displays as typed on the detail page
- [x] Edit a menu item — verify the name input shows as typed, not all-caps
- [x] Meal plan list — verify consistent appearance with detail page