### PR TITLE
fix(ui): disable Next button on meal plan edit when nothing changed

### DIFF
--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -46,6 +46,15 @@ export default function MealPlanEditPage() {
   const [selected, setSelected] = useState<Set<string> | null>(null);
   const current = selected ?? initialIds;
 
+  const isDirty = useMemo(() => {
+    if (selected === null) return false;
+    if (selected.size !== initialIds.size) return true;
+    for (const id of selected) {
+      if (!initialIds.has(id)) return true;
+    }
+    return false;
+  }, [selected, initialIds]);
+
   const [orderedItems, setOrderedItems] = useState<
     { id: string; name: string }[] | null
   >(null);
@@ -186,7 +195,7 @@ export default function MealPlanEditPage() {
         {mode === "select" ? (
           <button
             onClick={handleNext}
-            disabled={current.size === 0}
+            disabled={current.size === 0 || !isDirty}
             className="flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:opacity-30"
           >
             Next


### PR DESCRIPTION
## Summary
- Add `isDirty` check that compares current selection against initial meal plan items
- Next button is disabled until the user actually adds or removes an item from their selection
- Prevents unnecessary navigation to the reorder screen when nothing has changed

Closes #115

## Test plan
- [x] Go to `/meal-plan/edit` with an existing meal plan — Next button should be grayed out
- [x] Toggle an item off — Next button activates
- [x] Toggle it back on (back to original state) — Next button disables again
- [x] With empty meal plan — Next stays disabled until at least one item is checked