### PR TITLE
fix(ui): hide Next bar until selection is dirty

### DIFF
--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -193,13 +193,14 @@ export default function MealPlanEditPage() {
           <p className="p-3 text-xs text-red-600 tracking-wider bg-white border-t border-black">{error}</p>
         )}
         {mode === "select" ? (
-          <button
-            onClick={handleNext}
-            disabled={current.size === 0 || !isDirty}
-            className="flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:opacity-30"
-          >
-            Next
-          </button>
+          isDirty && (
+            <button
+              onClick={handleNext}
+              className="flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white"
+            >
+              Next
+            </button>
+          )
         ) : (
           <button
             onClick={handleSave}


### PR DESCRIPTION
## Summary
- Hide the Next button entirely (not just disabled) until the user changes their meal plan selection
- Cleaner UX — no dead button taking up space when there's nothing to do

Follow-up to #117

## Test plan
- [ ] Go to `/meal-plan/edit` with an existing meal plan — no Next bar visible
- [ ] Toggle an item — Next bar appears
- [ ] Toggle back to original state — Next bar disappears