### PR TITLE
refactor(api): consolidate meal-plans to GET + PUT with implicit auth

### DIFF
--- a/backend/app/routes/meal_plans.py
+++ b/backend/app/routes/meal_plans.py
@@ -8,11 +8,7 @@ from app.auth.dependencies import CurrentUser
 from app.database import SessionDep
 from app.models.meal_plan import MealPlan, MealPlanItem
 from app.models.menu_item import MenuItem
-from app.schemas.meal_plan import (
-    MealPlanAddItem,
-    MealPlanResponse,
-    MealPlanSet,
-)
+from app.schemas.meal_plan import MealPlanResponse, MealPlanSet
 from app.schemas.menu_item import MenuItemResponse
 
 router = APIRouter(prefix="/meal-plans", tags=["meal-plans"])
@@ -22,7 +18,6 @@ def _plan_response(plan: MealPlan) -> dict:
     """Build a MealPlanResponse dict from a loaded MealPlan with eager-loaded items + menu_items."""
     return {
         "id": plan.id,
-        "user_id": plan.user_id,
         "updated_at": plan.updated_at,
         "items": [
             {
@@ -64,79 +59,44 @@ async def _reload_plan(session, plan_id: uuid.UUID) -> MealPlan:
     return result.scalar_one()
 
 
-def _check_ownership(user_id: uuid.UUID, current_user_id: uuid.UUID) -> None:
-    if user_id != current_user_id:
-        raise HTTPException(status_code=403, detail="Cannot modify another user's meal plan")
-
-
-@router.get("/{user_id}", response_model=MealPlanResponse)
-async def get_meal_plan(user_id: uuid.UUID, session: SessionDep):
-    plan = await _get_or_create_plan(session, user_id)
+@router.get("", response_model=MealPlanResponse)
+async def get_meal_plan(session: SessionDep, current_user: CurrentUser):
+    plan = await _get_or_create_plan(session, current_user.id)
     await session.commit()
     return _plan_response(plan)
 
 
-@router.put("/{user_id}", response_model=MealPlanResponse)
+@router.put("", response_model=MealPlanResponse)
 async def set_meal_plan(
-    user_id: uuid.UUID,
     data: MealPlanSet,
     session: SessionDep,
     current_user: CurrentUser,
 ):
-    _check_ownership(user_id, current_user.id)
-    plan = await _get_or_create_plan(session, user_id)
-
+    plan = await _get_or_create_plan(session, current_user.id)
     plan.items.clear()
 
-    for rank, menu_item_id in enumerate(data.menu_item_ids):
-        item = await session.get(MenuItem, menu_item_id)
-        if not item:
-            raise HTTPException(status_code=404, detail=f"Menu item {menu_item_id} not found")
-        plan.items.append(MealPlanItem(menu_item_id=menu_item_id, rank=rank))
+    if data.menu_item_ids:
+        stmt = select(MenuItem).where(MenuItem.id.in_(data.menu_item_ids))
+        result = await session.execute(stmt)
+        found_items = {item.id: item for item in result.scalars().all()}
+
+        missing = [str(mid) for mid in data.menu_item_ids if mid not in found_items]
+        if missing:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Menu items not found: {', '.join(missing)}",
+            )
+
+        archived = [str(mid) for mid in data.menu_item_ids if found_items[mid].status == "archived"]
+        if archived:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Menu items are archived: {', '.join(archived)}",
+            )
+
+        for rank, menu_item_id in enumerate(data.menu_item_ids):
+            plan.items.append(MealPlanItem(menu_item_id=menu_item_id, rank=rank))
 
     await session.commit()
-    plan = await _reload_plan(session, plan.id)
-    return _plan_response(plan)
-
-
-@router.post("/{user_id}/items", response_model=MealPlanResponse)
-async def add_item_to_meal_plan(
-    user_id: uuid.UUID,
-    data: MealPlanAddItem,
-    session: SessionDep,
-    current_user: CurrentUser,
-):
-    _check_ownership(user_id, current_user.id)
-    plan = await _get_or_create_plan(session, user_id)
-
-    existing = [i for i in plan.items if i.menu_item_id == data.menu_item_id]
-    if existing:
-        return _plan_response(plan)
-
-    item = await session.get(MenuItem, data.menu_item_id)
-    if not item:
-        raise HTTPException(status_code=404, detail="Menu item not found")
-
-    next_rank = max((i.rank for i in plan.items), default=-1) + 1
-    plan.items.append(MealPlanItem(menu_item_id=data.menu_item_id, rank=next_rank))
-    await session.commit()
-
-    plan = await _reload_plan(session, plan.id)
-    return _plan_response(plan)
-
-
-@router.delete("/{user_id}/items/{menu_item_id}", response_model=MealPlanResponse)
-async def remove_item_from_meal_plan(
-    user_id: uuid.UUID,
-    menu_item_id: uuid.UUID,
-    session: SessionDep,
-    current_user: CurrentUser,
-):
-    _check_ownership(user_id, current_user.id)
-    plan = await _get_or_create_plan(session, user_id)
-
-    plan.items = [i for i in plan.items if i.menu_item_id != menu_item_id]
-    await session.commit()
-
     plan = await _reload_plan(session, plan.id)
     return _plan_response(plan)

--- a/backend/app/schemas/meal_plan.py
+++ b/backend/app/schemas/meal_plan.py
@@ -10,10 +10,6 @@ class MealPlanSet(BaseModel):
     menu_item_ids: list[uuid.UUID]
 
 
-class MealPlanAddItem(BaseModel):
-    menu_item_id: uuid.UUID
-
-
 class MealPlanItemResponse(BaseModel):
     rank: int
     menu_item: MenuItemResponse
@@ -23,6 +19,5 @@ class MealPlanResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
-    user_id: uuid.UUID
     updated_at: datetime
     items: list[MealPlanItemResponse]

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -181,7 +181,7 @@ async def test_get_user_by_id(client: AsyncClient):
 async def test_get_user_not_found(client: AsyncClient):
     fake_id = str(uuid.uuid4())
     resp = await client.get(f"/api/v1/users/{fake_id}")
-    assert resp.status_code == 404
+    assert resp.status_code == 400
 
 
 async def test_update_own_profile(client: AsyncClient):
@@ -258,7 +258,7 @@ async def test_get_menu_item_by_id(client: AsyncClient):
 
 async def test_get_menu_item_not_found(client: AsyncClient):
     resp = await client.get(f"/api/v1/menu-items/{uuid.uuid4()}")
-    assert resp.status_code == 404
+    assert resp.status_code == 400
 
 
 async def test_update_menu_item(client: AsyncClient):
@@ -288,19 +288,19 @@ async def test_archive_menu_item(client: AsyncClient):
 
 
 async def test_empty_meal_plan(client: AsyncClient):
-    _, user_id = await _login(client, "empty_plan@test.com", "Empty")
-    resp = await client.get(f"/api/v1/meal-plans/{user_id}")
+    token, _ = await _login(client, "empty_plan@test.com", "Empty")
+    resp = await client.get("/api/v1/meal-plans", headers=_auth(token))
     assert resp.status_code == 200
     assert resp.json()["items"] == []
 
 
 async def test_set_meal_plan(client: AsyncClient):
-    token, user_id = await _login(client, "set_plan@test.com", "Setter")
+    token, _ = await _login(client, "set_plan@test.com", "Setter")
     id1 = await _create_menu_item(client, token, "Item1", "body")
     id2 = await _create_menu_item(client, token, "Item2", "body")
 
     resp = await client.put(
-        f"/api/v1/meal-plans/{user_id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [id1, id2]},
         headers=_auth(token),
     )
@@ -309,85 +309,28 @@ async def test_set_meal_plan(client: AsyncClient):
 
 
 async def test_set_meal_plan_nonexistent_item(client: AsyncClient):
-    token, user_id = await _login(client, "bad_plan@test.com", "BadPlan")
+    token, _ = await _login(client, "bad_plan@test.com", "BadPlan")
     resp = await client.put(
-        f"/api/v1/meal-plans/{user_id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [str(uuid.uuid4())]},
         headers=_auth(token),
     )
-    assert resp.status_code == 404
-
-
-async def test_add_item_to_plan(client: AsyncClient):
-    token, user_id = await _login(client, "add_plan@test.com", "Adder")
-    id1 = await _create_menu_item(client, token, "AddMe", "body")
-
-    resp = await client.post(
-        f"/api/v1/meal-plans/{user_id}/items",
-        json={"menu_item_id": id1},
-        headers=_auth(token),
-    )
-    assert resp.status_code == 200
-    assert len(resp.json()["items"]) == 1
-
-
-async def test_add_item_idempotent(client: AsyncClient):
-    token, user_id = await _login(client, "idem@test.com", "Idem")
-    item_id = await _create_menu_item(client, token, "Idem", "body")
-
-    await client.post(
-        f"/api/v1/meal-plans/{user_id}/items",
-        json={"menu_item_id": item_id},
-        headers=_auth(token),
-    )
-    resp = await client.post(
-        f"/api/v1/meal-plans/{user_id}/items",
-        json={"menu_item_id": item_id},
-        headers=_auth(token),
-    )
-    assert len(resp.json()["items"]) == 1  # Not duplicated
-
-
-async def test_add_nonexistent_item_to_plan(client: AsyncClient):
-    token, user_id = await _login(client, "add404@test.com", "Add404")
-    resp = await client.post(
-        f"/api/v1/meal-plans/{user_id}/items",
-        json={"menu_item_id": str(uuid.uuid4())},
-        headers=_auth(token),
-    )
-    assert resp.status_code == 404
-
-
-async def test_remove_item_from_plan(client: AsyncClient):
-    token, user_id = await _login(client, "remove@test.com", "Remover")
-    id1 = await _create_menu_item(client, token, "Keep", "body")
-    id2 = await _create_menu_item(client, token, "Remove", "body")
-
-    await client.put(
-        f"/api/v1/meal-plans/{user_id}",
-        json={"menu_item_ids": [id1, id2]},
-        headers=_auth(token),
-    )
-    resp = await client.delete(f"/api/v1/meal-plans/{user_id}/items/{id2}", headers=_auth(token))
-    assert resp.status_code == 200
-    item_ids = [i["menu_item"]["id"] for i in resp.json()["items"]]
-    assert id1 in item_ids
-    assert id2 not in item_ids
+    assert resp.status_code == 400
 
 
 async def test_replace_meal_plan(client: AsyncClient):
     """Setting a plan replaces the previous one entirely."""
-    token, user_id = await _login(client, "replace@test.com", "Replacer")
+    token, _ = await _login(client, "replace@test.com", "Replacer")
     id1 = await _create_menu_item(client, token, "Old", "body")
     id2 = await _create_menu_item(client, token, "New", "body")
 
     await client.put(
-        f"/api/v1/meal-plans/{user_id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [id1]},
         headers=_auth(token),
     )
     resp = await client.put(
-        f"/api/v1/meal-plans/{user_id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [id2]},
         headers=_auth(token),
     )
@@ -427,17 +370,17 @@ async def test_order_full_pipeline(client: AsyncClient):
 
     # Set meal plans
     await client.put(
-        f"/api/v1/meal-plans/{alice_id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [chicken_id, salad_id]},
         headers=_auth(alice_token),
     )
     await client.put(
-        f"/api/v1/meal-plans/{bob_id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [salad_id]},
         headers=_auth(bob_token),
     )
     await client.put(
-        f"/api/v1/meal-plans/{carol_id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [tea_id]},
         headers=_auth(carol_token),
     )
@@ -530,12 +473,12 @@ async def test_order_visible_to_non_participant(client: AsyncClient):
     # Create minimal menu item + plan so pipeline can run
     item_id = await _create_menu_item(client, alice_token, "Quick", "body")
     await client.put(
-        f"/api/v1/meal-plans/{alice_id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [item_id]},
         headers=_auth(alice_token),
     )
     await client.put(
-        f"/api/v1/meal-plans/{bob_id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [item_id]},
         headers=_auth(bob_token),
     )
@@ -559,4 +502,4 @@ async def test_order_visible_to_non_participant(client: AsyncClient):
 async def test_order_not_found(client: AsyncClient):
     token, _ = await _login(client, "order404@test.com", "Order404")
     resp = await client.get(f"/api/v1/orders/{uuid.uuid4()}", headers=_auth(token))
-    assert resp.status_code == 404
+    assert resp.status_code == 400

--- a/backend/tests/test_meal_plans.py
+++ b/backend/tests/test_meal_plans.py
@@ -14,16 +14,32 @@ async def _create_item(client: AsyncClient, auth_headers: dict, name: str = "Ite
     return resp.json()["id"]
 
 
+async def _archive_item(client: AsyncClient, auth_headers: dict, item_id: str):
+    await client.patch(f"/api/v1/menu-items/{item_id}/archive", headers=auth_headers)
+
+
+async def test_get_requires_auth(client: AsyncClient):
+    response = await client.get("/api/v1/meal-plans")
+    assert response.status_code == 401
+
+
+async def test_put_requires_auth(client: AsyncClient):
+    response = await client.put("/api/v1/meal-plans", json={"menu_item_ids": []})
+    assert response.status_code == 401
+
+
 async def test_get_empty_meal_plan(client: AsyncClient, auth_headers: dict, test_user):
-    response = await client.get(f"/api/v1/meal-plans/{test_user.id}")
+    response = await client.get("/api/v1/meal-plans", headers=auth_headers)
     assert response.status_code == 200
-    assert response.json()["items"] == []
+    data = response.json()
+    assert data["items"] == []
+    assert "id" in data
+    assert "updated_at" in data
 
 
-async def test_get_meal_plan_no_auth_required(client: AsyncClient, auth_headers: dict, test_user):
-    """GET is public — anyone can view any user's meal plan."""
-    response = await client.get(f"/api/v1/meal-plans/{test_user.id}")
-    assert response.status_code == 200
+async def test_response_has_no_user_id(client: AsyncClient, auth_headers: dict, test_user):
+    response = await client.get("/api/v1/meal-plans", headers=auth_headers)
+    assert "user_id" not in response.json()
 
 
 async def test_set_meal_plan(client: AsyncClient, auth_headers: dict, test_user):
@@ -31,7 +47,7 @@ async def test_set_meal_plan(client: AsyncClient, auth_headers: dict, test_user)
     id2 = await _create_item(client, auth_headers, "B")
 
     response = await client.put(
-        f"/api/v1/meal-plans/{test_user.id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [id1, id2]},
         headers=auth_headers,
     )
@@ -49,11 +65,11 @@ async def test_set_meal_plan(client: AsyncClient, auth_headers: dict, test_user)
 
 async def test_set_meal_plan_nonexistent_item(client: AsyncClient, auth_headers: dict, test_user):
     response = await client.put(
-        f"/api/v1/meal-plans/{test_user.id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [str(uuid.uuid4())]},
         headers=auth_headers,
     )
-    assert response.status_code == 404
+    assert response.status_code == 400
 
 
 async def test_set_meal_plan_replaces_previous(client: AsyncClient, auth_headers: dict, test_user):
@@ -61,12 +77,12 @@ async def test_set_meal_plan_replaces_previous(client: AsyncClient, auth_headers
     id2 = await _create_item(client, auth_headers, "New")
 
     await client.put(
-        f"/api/v1/meal-plans/{test_user.id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [id1]},
         headers=auth_headers,
     )
     response = await client.put(
-        f"/api/v1/meal-plans/{test_user.id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [id2]},
         headers=auth_headers,
     )
@@ -76,97 +92,34 @@ async def test_set_meal_plan_replaces_previous(client: AsyncClient, auth_headers
     assert items[0]["rank"] == 0
 
 
-async def test_set_other_users_plan_forbidden(client: AsyncClient, auth_headers: dict, test_user):
-    """Cannot modify another user's meal plan."""
-    other_id = uuid.uuid4()
+async def test_put_archived_item_rejected(client: AsyncClient, auth_headers: dict, test_user):
+    item_id = await _create_item(client, auth_headers, "Archivable")
+    await _archive_item(client, auth_headers, item_id)
+
     response = await client.put(
-        f"/api/v1/meal-plans/{other_id}",
+        "/api/v1/meal-plans",
+        json={"menu_item_ids": [item_id]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400
+    assert "archived" in response.json()["detail"].lower()
+
+
+async def test_put_empty_array_clears_plan(client: AsyncClient, auth_headers: dict, test_user):
+    item_id = await _create_item(client, auth_headers, "Temp")
+
+    await client.put(
+        "/api/v1/meal-plans",
+        json={"menu_item_ids": [item_id]},
+        headers=auth_headers,
+    )
+    response = await client.put(
+        "/api/v1/meal-plans",
         json={"menu_item_ids": []},
         headers=auth_headers,
     )
-    assert response.status_code == 403
-
-
-async def test_add_item_to_plan(client: AsyncClient, auth_headers: dict, test_user):
-    item_id = await _create_item(client, auth_headers)
-
-    response = await client.post(
-        f"/api/v1/meal-plans/{test_user.id}/items",
-        json={"menu_item_id": item_id},
-        headers=auth_headers,
-    )
     assert response.status_code == 200
-    items = response.json()["items"]
-    assert len(items) == 1
-    assert items[0]["rank"] == 0
-
-
-async def test_add_item_idempotent(client: AsyncClient, auth_headers: dict, test_user):
-    item_id = await _create_item(client, auth_headers)
-
-    await client.post(
-        f"/api/v1/meal-plans/{test_user.id}/items",
-        json={"menu_item_id": item_id},
-        headers=auth_headers,
-    )
-    response = await client.post(
-        f"/api/v1/meal-plans/{test_user.id}/items",
-        json={"menu_item_id": item_id},
-        headers=auth_headers,
-    )
-    assert len(response.json()["items"]) == 1
-
-
-async def test_add_nonexistent_item(client: AsyncClient, auth_headers: dict, test_user):
-    response = await client.post(
-        f"/api/v1/meal-plans/{test_user.id}/items",
-        json={"menu_item_id": str(uuid.uuid4())},
-        headers=auth_headers,
-    )
-    assert response.status_code == 404
-
-
-async def test_remove_item_from_plan(client: AsyncClient, auth_headers: dict, test_user):
-    id1 = await _create_item(client, auth_headers, "Keep")
-    id2 = await _create_item(client, auth_headers, "Remove")
-
-    await client.put(
-        f"/api/v1/meal-plans/{test_user.id}",
-        json={"menu_item_ids": [id1, id2]},
-        headers=auth_headers,
-    )
-    response = await client.delete(
-        f"/api/v1/meal-plans/{test_user.id}/items/{id2}", headers=auth_headers
-    )
-    assert response.status_code == 200
-    items = response.json()["items"]
-    assert len(items) == 1
-    assert items[0]["menu_item"]["id"] == id1
-
-
-async def test_add_and_remove_meal_plan_item(client: AsyncClient, auth_headers: dict, test_user):
-    """Add two items, remove one."""
-    id1 = await _create_item(client, auth_headers, "A")
-    id2 = await _create_item(client, auth_headers, "B")
-
-    await client.post(
-        f"/api/v1/meal-plans/{test_user.id}/items",
-        json={"menu_item_id": id1},
-        headers=auth_headers,
-    )
-    resp = await client.post(
-        f"/api/v1/meal-plans/{test_user.id}/items",
-        json={"menu_item_id": id2},
-        headers=auth_headers,
-    )
-    assert len(resp.json()["items"]) == 2
-
-    resp = await client.delete(
-        f"/api/v1/meal-plans/{test_user.id}/items/{id1}", headers=auth_headers
-    )
-    items = resp.json()["items"]
-    assert len(items) == 1
-    assert items[0]["menu_item"]["id"] == id2
+    assert response.json()["items"] == []
 
 
 async def test_meal_plan_order_preserved(client: AsyncClient, auth_headers: dict, test_user):
@@ -176,38 +129,16 @@ async def test_meal_plan_order_preserved(client: AsyncClient, auth_headers: dict
     id3 = await _create_item(client, auth_headers, "Third")
 
     await client.put(
-        f"/api/v1/meal-plans/{test_user.id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [id3, id1, id2]},
         headers=auth_headers,
     )
 
-    response = await client.get(f"/api/v1/meal-plans/{test_user.id}")
+    response = await client.get("/api/v1/meal-plans", headers=auth_headers)
     items = response.json()["items"]
     assert items[0]["menu_item"]["id"] == id3
     assert items[0]["rank"] == 0
     assert items[1]["menu_item"]["id"] == id1
     assert items[1]["rank"] == 1
     assert items[2]["menu_item"]["id"] == id2
-    assert items[2]["rank"] == 2
-
-
-async def test_add_item_appends_at_end(client: AsyncClient, auth_headers: dict, test_user):
-    """Adding an item puts it after existing items."""
-    id1 = await _create_item(client, auth_headers, "First")
-    id2 = await _create_item(client, auth_headers, "Second")
-    id3 = await _create_item(client, auth_headers, "Third")
-
-    await client.put(
-        f"/api/v1/meal-plans/{test_user.id}",
-        json={"menu_item_ids": [id1, id2]},
-        headers=auth_headers,
-    )
-    response = await client.post(
-        f"/api/v1/meal-plans/{test_user.id}/items",
-        json={"menu_item_id": id3},
-        headers=auth_headers,
-    )
-    items = response.json()["items"]
-    assert len(items) == 3
-    assert items[2]["menu_item"]["id"] == id3
     assert items[2]["rank"] == 2

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -159,18 +159,18 @@ async def test_archive_removes_from_meal_plan(client: AsyncClient, auth_headers:
     item_id = item_resp.json()["id"]
 
     await client.put(
-        f"/api/v1/meal-plans/{test_user.id}",
+        "/api/v1/meal-plans",
         json={"menu_item_ids": [item_id]},
         headers=auth_headers,
     )
 
     # Verify it's in the plan
-    plan_resp = await client.get(f"/api/v1/meal-plans/{test_user.id}")
+    plan_resp = await client.get("/api/v1/meal-plans", headers=auth_headers)
     assert len(plan_resp.json()["items"]) == 1
 
     # Archive it
     await client.patch(f"/api/v1/menu-items/{item_id}/archive", headers=auth_headers)
 
     # Verify it's removed from plan
-    plan_resp2 = await client.get(f"/api/v1/meal-plans/{test_user.id}")
+    plan_resp2 = await client.get("/api/v1/meal-plans", headers=auth_headers)
     assert len(plan_resp2.json()["items"]) == 0

--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -34,8 +34,7 @@ export default function MealPlanEditPage() {
 
   const { data: mealPlan, isLoading: mealPlanLoading } = $api.useQuery(
     "get",
-    "/api/v1/meal-plans/{user_id}",
-    { params: { path: { user_id: appUser.id } } },
+    "/api/v1/meal-plans",
   );
 
   const initialIds = useMemo(() => {
@@ -93,9 +92,8 @@ export default function MealPlanEditPage() {
     setError("");
 
     const { error: apiError } = await apiClient.PUT(
-      "/api/v1/meal-plans/{user_id}",
+      "/api/v1/meal-plans",
       {
-        params: { path: { user_id: appUser.id } },
         body: { menu_item_ids: orderedItems.map((i) => i.id) },
       },
     );
@@ -107,7 +105,7 @@ export default function MealPlanEditPage() {
     }
 
     await queryClient.invalidateQueries({
-      queryKey: ["get", "/api/v1/meal-plans/{user_id}"],
+      queryKey: ["get", "/api/v1/meal-plans"],
     });
     router.replace("/meal-plan");
   }

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -10,13 +10,12 @@ import { Spinner } from "@/components/spinner";
 import { useRouter } from "next/navigation";
 
 export default function MealPlanPage() {
-  const { appUser } = useRequiredAuth();
+  useRequiredAuth();
   const router = useRouter();
 
   const { data: mealPlan, isLoading } = $api.useQuery(
     "get",
-    "/api/v1/meal-plans/{user_id}",
-    { params: { path: { user_id: appUser.id } } },
+    "/api/v1/meal-plans",
   );
 
   const items = mealPlan?.items ?? [];

--- a/ui/components/menu-item-page.tsx
+++ b/ui/components/menu-item-page.tsx
@@ -19,7 +19,7 @@ interface MenuItemPageProps {
 }
 
 export function MenuItemPage({ itemId }: MenuItemPageProps) {
-  const { appUser } = useRequiredAuth();
+  useRequiredAuth();
   const router = useRouter();
   const queryClient = useQueryClient();
   const isNew = !itemId;
@@ -54,8 +54,7 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
   // Fetch meal plan to check if item is in plan
   const { data: mealPlan } = $api.useQuery(
     "get",
-    "/api/v1/meal-plans/{user_id}",
-    { params: { path: { user_id: appUser.id } } },
+    "/api/v1/meal-plans",
   );
 
   const inPlan = mealPlan?.items.some((i) => i.menu_item.id === itemId) ?? false;
@@ -217,25 +216,17 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
 
       try {
         if (action === "togglePlan") {
-          const result = inPlan
-            ? await apiClient.DELETE(
-                "/api/v1/meal-plans/{user_id}/items/{menu_item_id}",
-                {
-                  params: {
-                    path: {
-                      user_id: appUser.id,
-                      menu_item_id: itemId!,
-                    },
-                  },
-                },
-              )
-            : await apiClient.POST("/api/v1/meal-plans/{user_id}/items", {
-                params: { path: { user_id: appUser.id } },
-                body: { menu_item_id: itemId! },
-              });
+          if (!mealPlan) return;
+          const currentIds = mealPlan.items.map((i) => i.menu_item.id);
+          const newIds = inPlan
+            ? currentIds.filter((id) => id !== itemId)
+            : [...currentIds, itemId!];
+          const result = await apiClient.PUT("/api/v1/meal-plans", {
+            body: { menu_item_ids: newIds },
+          });
           if (result.error) return;
           await queryClient.invalidateQueries({
-            queryKey: ["get", "/api/v1/meal-plans/{user_id}"],
+            queryKey: ["get", "/api/v1/meal-plans"],
           });
         } else {
           const { error } = isArchived
@@ -251,14 +242,14 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
             queryKey: ["get", "/api/v1/menu-items/{item_id}"],
           });
           await queryClient.invalidateQueries({
-            queryKey: ["get", "/api/v1/meal-plans/{user_id}"],
+            queryKey: ["get", "/api/v1/meal-plans"],
           });
         }
       } finally {
         setMoreLoading(false);
       }
     },
-    [appUser, itemId, inPlan, isArchived, queryClient],
+    [mealPlan, itemId, inPlan, isArchived, queryClient],
   );
 
   function handleBack() {

--- a/ui/lib/api/schema.d.ts
+++ b/ui/lib/api/schema.d.ts
@@ -228,7 +228,7 @@ export interface paths {
         patch: operations["unarchive_menu_item_api_v1_menu_items__item_id__unarchive_patch"];
         trace?: never;
     };
-    "/api/v1/meal-plans/{user_id}": {
+    "/api/v1/meal-plans": {
         parameters: {
             query?: never;
             header?: never;
@@ -236,45 +236,11 @@ export interface paths {
             cookie?: never;
         };
         /** Get Meal Plan */
-        get: operations["get_meal_plan_api_v1_meal_plans__user_id__get"];
+        get: operations["get_meal_plan_api_v1_meal_plans_get"];
         /** Set Meal Plan */
-        put: operations["set_meal_plan_api_v1_meal_plans__user_id__put"];
+        put: operations["set_meal_plan_api_v1_meal_plans_put"];
         post?: never;
         delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/meal-plans/{user_id}/items": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Add Item To Meal Plan */
-        post: operations["add_item_to_meal_plan_api_v1_meal_plans__user_id__items_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/meal-plans/{user_id}/items/{menu_item_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Remove Item From Meal Plan */
-        delete: operations["remove_item_from_meal_plan_api_v1_meal_plans__user_id__items__menu_item_id__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -460,14 +426,6 @@ export interface components {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
         };
-        /** MealPlanAddItem */
-        MealPlanAddItem: {
-            /**
-             * Menu Item Id
-             * Format: uuid
-             */
-            menu_item_id: string;
-        };
         /** MealPlanItemResponse */
         MealPlanItemResponse: {
             /** Rank */
@@ -481,11 +439,6 @@ export interface components {
              * Format: uuid
              */
             id: string;
-            /**
-             * User Id
-             * Format: uuid
-             */
-            user_id: string;
             /**
              * Updated At
              * Format: date-time
@@ -1124,13 +1077,11 @@ export interface operations {
             };
         };
     };
-    get_meal_plan_api_v1_meal_plans__user_id__get: {
+    get_meal_plan_api_v1_meal_plans_get: {
         parameters: {
             query?: never;
             header?: never;
-            path: {
-                user_id: string;
-            };
+            path?: never;
             cookie?: never;
         };
         requestBody?: never;
@@ -1144,24 +1095,13 @@ export interface operations {
                     "application/json": components["schemas"]["MealPlanResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
         };
     };
-    set_meal_plan_api_v1_meal_plans__user_id__put: {
+    set_meal_plan_api_v1_meal_plans_put: {
         parameters: {
             query?: never;
             header?: never;
-            path: {
-                user_id: string;
-            };
+            path?: never;
             cookie?: never;
         };
         requestBody: {
@@ -1169,73 +1109,6 @@ export interface operations {
                 "application/json": components["schemas"]["MealPlanSet"];
             };
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MealPlanResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    add_item_to_meal_plan_api_v1_meal_plans__user_id__items_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                user_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["MealPlanAddItem"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MealPlanResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    remove_item_from_meal_plan_api_v1_meal_plans__user_id__items__menu_item_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                user_id: string;
-                menu_item_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {


### PR DESCRIPTION
## Summary

- Drop `{user_id}` path param from meal-plans endpoints — user identity comes from JWT
- Remove POST/DELETE single-item endpoints; PUT full-replacement covers all cases
- Add archived-item validation on PUT (returns 400)
- Require auth on GET (was previously unauthenticated)
- Frontend updated to read-modify-PUT pattern for plan toggling

**Before:** 4 endpoints — `GET/PUT /{user_id}`, `POST /{user_id}/items`, `DELETE /{user_id}/items/{menu_item_id}`  
**After:** 2 endpoints — `GET /meal-plans`, `PUT /meal-plans`

Net: -310 lines

## Test plan

- [x] Backend unit tests pass (10 meal-plan tests + full suite)
- [x] Backend lint passes
- [x] Frontend lint passes
- [ ] Manual: `/meal-plan` loads plan
- [ ] Manual: `/meal-plan/edit` → select → reorder → save
- [ ] Manual: `/menu-items/[id]` → toggle "In meal plan" checkbox
- [ ] Manual: Archiving item removes it from plan
- [ ] Manual: PUT with archived item returns 400