### PR TITLE
fix(ui): align invoice FAB height with menu-item FAB

### DIFF
--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -68,7 +68,7 @@ export default function MealPlanPage() {
         <button
           onClick={() => router.push("/invoice")}
           aria-label="New expense"
-          className="fixed bottom-12 right-12 flex h-14 w-14 items-center justify-center bg-black text-white shadow-[4px_4px_0_rgba(0,0,0,0.2)]"
+          className="fixed bottom-24 right-12 flex h-14 w-14 items-center justify-center bg-black text-white shadow-[4px_4px_0_rgba(0,0,0,0.2)]"
         >
           <Icon name="receipt_long" size={24} />
         </button>


### PR DESCRIPTION
## Summary

- Match the invoice FAB on `/meal-plan` to `bottom-24` (was `bottom-12`), consistent with the menu-item FAB on `/meal-plan/edit`

## Test plan

- [ ] Visual: both FABs sit at the same height from bottom