### PR TITLE
refactor(ui): rename /profile to /me → /user/[id]

### DIFF
--- a/ui/app/(authenticated)/me/page.tsx
+++ b/ui/app/(authenticated)/me/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useRequiredAuth } from "@/lib/auth";
+
+export default function MePage() {
+  const { appUser } = useRequiredAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace(`/user/${appUser.id}`);
+  }, [appUser.id, router]);
+
+  return null;
+}

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -68,7 +68,7 @@ export default function MealPlanPage() {
         <button
           onClick={() => router.push("/invoice")}
           aria-label="New expense"
-          className="fixed bottom-12 right-12 flex h-14 w-14 items-center justify-center bg-black text-white shadow-[4px_4px_0_rgba(0,0,0,0.2)]"
+          className="fixed bottom-24 right-12 flex h-14 w-14 items-center justify-center bg-black text-white shadow-[4px_4px_0_rgba(0,0,0,0.2)]"
         >
           <Icon name="receipt_long" size={24} />
         </button>

--- a/ui/app/(authenticated)/user/[id]/page.tsx
+++ b/ui/app/(authenticated)/user/[id]/page.tsx
@@ -1,22 +1,29 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useParams } from "next/navigation";
 import { useRequiredAuth } from "@/lib/auth";
 import { TopBar } from "@/components/top-bar";
 import { Icon } from "@/components/icon";
 import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog";
 import apiClient from "@/lib/api/client";
 
-export default function ProfilePage() {
+export default function UserPage() {
   const { appUser, signOut } = useRequiredAuth();
   const router = useRouter();
+  const params = useParams<{ id: string }>();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
   const [error, setError] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const settingsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (params.id !== appUser.id) {
+      router.replace("/me");
+    }
+  }, [params.id, appUser.id, router]);
 
   useEffect(() => {
     if (!settingsOpen) return;
@@ -46,6 +53,8 @@ export default function ProfilePage() {
     await signOut();
     router.replace("/login");
   }
+
+  if (params.id !== appUser.id) return null;
 
   return (
     <div className="flex flex-1 flex-col">

--- a/ui/components/top-bar.tsx
+++ b/ui/components/top-bar.tsx
@@ -16,7 +16,7 @@ export function TopBar({ showBack = false, onBack, rightAction }: TopBarProps) {
 
   const defaultRight = appUser ? (
     <button
-      onClick={() => router.push("/profile")}
+      onClick={() => router.push("/me")}
       aria-label="Profile"
       className="flex h-full w-full items-center justify-center"
     >


### PR DESCRIPTION
## Summary

- `/me` redirects to `/user/{appUser.id}` (convenience shortcut)
- `/user/[id]` renders the profile page; guards against id mismatch by redirecting to `/me`
- `/profile` deleted
- TopBar avatar link updated to `/me`

Structural prep for future cross-user profile viewing.

## Test plan

- [ ] TopBar avatar → `/me` → redirects to `/user/{your-id}` → profile renders
- [ ] Manually navigate to `/user/other-id` → redirects to `/me` → lands on own profile
- [ ] Back button goes to `/meal-plan`
- [ ] Sign out and delete account still work
- [ ] Browser back from `/user/{id}` goes to previous page (not `/me`)