### PR TITLE
refactor(api): menu-items auth, ownership 403, status enum, response fields

### DIFF
--- a/backend/app/routes/menu_items.py
+++ b/backend/app/routes/menu_items.py
@@ -12,15 +12,19 @@ from app.schemas.menu_item import MenuItemCreate, MenuItemResponse, MenuItemUpda
 
 router = APIRouter(prefix="/menu-items", tags=["menu-items"])
 
+VALID_STATUSES = {"active", "archived"}
 
-async def _get_own_item(session, item_id: uuid.UUID, user_id: uuid.UUID) -> MenuItem:
-    result = await session.execute(
-        select(MenuItem).where(MenuItem.id == item_id, MenuItem.created_by == user_id)
-    )
-    item = result.scalar_one_or_none()
+
+async def _get_item_or_404(session, item_id: uuid.UUID) -> MenuItem:
+    item = await session.get(MenuItem, item_id)
     if not item:
         raise HTTPException(status_code=404, detail="Menu item not found")
     return item
+
+
+def _check_owner(item: MenuItem, user_id: uuid.UUID):
+    if item.created_by != user_id:
+        raise HTTPException(status_code=403, detail="Not allowed to modify this item")
 
 
 @router.post("/", response_model=MenuItemResponse, status_code=201)
@@ -44,22 +48,25 @@ async def create_menu_item(
 @router.get("/", response_model=list[MenuItemResponse])
 async def list_menu_items(
     session: SessionDep,
+    current_user: CurrentUser,
     status: str = Query(default="active"),
-    created_by: uuid.UUID | None = Query(default=None),
 ):
-    stmt = select(MenuItem).where(MenuItem.status == status)
-    if created_by:
-        stmt = stmt.where(MenuItem.created_by == created_by)
+    statuses = [s.strip() for s in status.split(",")]
+    invalid = [s for s in statuses if s not in VALID_STATUSES]
+    if invalid:
+        raise HTTPException(status_code=400, detail=f"Invalid status: {', '.join(invalid)}")
+
+    stmt = select(MenuItem).where(
+        MenuItem.created_by == current_user.id,
+        MenuItem.status.in_(statuses),
+    )
     result = await session.execute(stmt)
     return result.scalars().all()
 
 
 @router.get("/{item_id}", response_model=MenuItemResponse)
 async def get_menu_item(item_id: uuid.UUID, session: SessionDep):
-    item = await session.get(MenuItem, item_id)
-    if not item:
-        raise HTTPException(status_code=404, detail="Menu item not found")
-    return item
+    return await _get_item_or_404(session, item_id)
 
 
 @router.patch("/{item_id}", response_model=MenuItemResponse)
@@ -69,7 +76,8 @@ async def update_menu_item(
     session: SessionDep,
     current_user: CurrentUser,
 ):
-    item = await _get_own_item(session, item_id, current_user.id)
+    item = await _get_item_or_404(session, item_id)
+    _check_owner(item, current_user.id)
 
     update_data = data.model_dump(exclude_unset=True)
     for key, value in update_data.items():
@@ -87,7 +95,8 @@ async def archive_menu_item(
     session: SessionDep,
     current_user: CurrentUser,
 ):
-    item = await _get_own_item(session, item_id, current_user.id)
+    item = await _get_item_or_404(session, item_id)
+    _check_owner(item, current_user.id)
 
     item.status = "archived"
     item.updated_by = current_user.id
@@ -112,7 +121,8 @@ async def unarchive_menu_item(
     session: SessionDep,
     current_user: CurrentUser,
 ):
-    item = await _get_own_item(session, item_id, current_user.id)
+    item = await _get_item_or_404(session, item_id)
+    _check_owner(item, current_user.id)
 
     item.status = "active"
     item.updated_by = current_user.id

--- a/backend/app/schemas/menu_item.py
+++ b/backend/app/schemas/menu_item.py
@@ -21,5 +21,7 @@ class MenuItemResponse(BaseModel):
     name: str
     body: str
     status: str
+    created_by: uuid.UUID
+    updated_by: uuid.UUID
     created_at: datetime
     updated_at: datetime

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -225,27 +225,23 @@ async def test_create_menu_item(client: AsyncClient):
 
 
 async def test_list_menu_items_with_filters(client: AsyncClient):
-    token, user_id = await _login(client, "filter@test.com", "Filter")
+    token, _ = await _login(client, "filter@test.com", "Filter")
     await _create_menu_item(client, token, "Active1", "body")
     id2 = await _create_menu_item(client, token, "Active2", "body")
 
     # Archive one
     await client.patch(f"/api/v1/menu-items/{id2}/archive", headers=_auth(token))
 
-    # Default listing (active only)
-    resp = await client.get("/api/v1/menu-items/")
+    # Default listing (active only, scoped to user)
+    resp = await client.get("/api/v1/menu-items/", headers=_auth(token))
     names = [i["name"] for i in resp.json()]
     assert "Active1" in names
     assert "Active2" not in names
 
     # Archived listing
-    resp = await client.get("/api/v1/menu-items/?status=archived")
+    resp = await client.get("/api/v1/menu-items/?status=archived", headers=_auth(token))
     names = [i["name"] for i in resp.json()]
     assert "Active2" in names
-
-    # Filter by creator
-    resp = await client.get(f"/api/v1/menu-items/?created_by={user_id}")
-    assert len(resp.json()) >= 1
 
 
 async def test_get_menu_item_by_id(client: AsyncClient):

--- a/backend/tests/test_menu_items.py
+++ b/backend/tests/test_menu_items.py
@@ -3,6 +3,10 @@
 import uuid
 
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import create_test_token
+from app.models.user import User
 
 
 async def test_create_menu_item(client: AsyncClient, auth_headers: dict):
@@ -20,15 +24,56 @@ async def test_create_menu_item(client: AsyncClient, auth_headers: dict):
     assert data["status"] == "active"
 
 
+async def test_list_requires_auth(client: AsyncClient):
+    response = await client.get("/api/v1/menu-items/")
+    assert response.status_code in (401, 403)
+
+
 async def test_list_menu_items(client: AsyncClient, auth_headers: dict):
     await client.post(
         "/api/v1/menu-items/",
         json={"name": "Salad", "body": "Chop veggies.\n\ncucumber, tomato"},
         headers=auth_headers,
     )
-    response = await client.get("/api/v1/menu-items/")
+    response = await client.get("/api/v1/menu-items/", headers=auth_headers)
     assert response.status_code == 200
     assert len(response.json()) == 1
+
+
+async def test_list_scoped_to_current_user(
+    client: AsyncClient, auth_headers: dict, test_user, session: AsyncSession
+):
+    """Each user only sees their own items."""
+    await client.post(
+        "/api/v1/menu-items/",
+        json={"name": "MyItem", "body": "mine"},
+        headers=auth_headers,
+    )
+
+    other_user = User(
+        email="other_list@example.com",
+        name="Other",
+        oauth_provider="google",
+        oauth_id="other-list-oauth",
+    )
+    session.add(other_user)
+    await session.commit()
+    other_token = create_test_token(other_user.oauth_id, other_user.email)
+    other_headers = {"Authorization": f"Bearer {other_token}"}
+
+    await client.post(
+        "/api/v1/menu-items/",
+        json={"name": "TheirItem", "body": "theirs"},
+        headers=other_headers,
+    )
+
+    my_items = await client.get("/api/v1/menu-items/", headers=auth_headers)
+    assert all(i["name"] != "TheirItem" for i in my_items.json())
+    assert any(i["name"] == "MyItem" for i in my_items.json())
+
+    their_items = await client.get("/api/v1/menu-items/", headers=other_headers)
+    assert all(i["name"] != "MyItem" for i in their_items.json())
+    assert any(i["name"] == "TheirItem" for i in their_items.json())
 
 
 async def test_list_menu_items_filter_by_status(client: AsyncClient, auth_headers: dict):
@@ -44,25 +89,48 @@ async def test_list_menu_items_filter_by_status(client: AsyncClient, auth_header
     )
     await client.patch(f"/api/v1/menu-items/{resp2.json()['id']}/archive", headers=auth_headers)
 
-    active = await client.get("/api/v1/menu-items/?status=active")
+    active = await client.get("/api/v1/menu-items/?status=active", headers=auth_headers)
     assert all(i["status"] == "active" for i in active.json())
     assert any(i["name"] == "Active" for i in active.json())
 
-    archived = await client.get("/api/v1/menu-items/?status=archived")
+    archived = await client.get("/api/v1/menu-items/?status=archived", headers=auth_headers)
     assert all(i["status"] == "archived" for i in archived.json())
 
 
-async def test_list_menu_items_filter_by_creator(
-    client: AsyncClient, auth_headers: dict, test_user
-):
+async def test_list_multiple_statuses(client: AsyncClient, auth_headers: dict):
     await client.post(
         "/api/v1/menu-items/",
-        json={"name": "Mine", "body": "my item body"},
+        json={"name": "ActiveMulti", "body": "body"},
         headers=auth_headers,
     )
-    response = await client.get(f"/api/v1/menu-items/?created_by={test_user.id}")
-    assert response.status_code == 200
-    assert len(response.json()) >= 1
+    resp2 = await client.post(
+        "/api/v1/menu-items/",
+        json={"name": "ArchivedMulti", "body": "body"},
+        headers=auth_headers,
+    )
+    await client.patch(f"/api/v1/menu-items/{resp2.json()['id']}/archive", headers=auth_headers)
+
+    both = await client.get("/api/v1/menu-items/?status=active,archived", headers=auth_headers)
+    assert both.status_code == 200
+    names = [i["name"] for i in both.json()]
+    assert "ActiveMulti" in names
+    assert "ArchivedMulti" in names
+
+
+async def test_list_invalid_status(client: AsyncClient, auth_headers: dict):
+    response = await client.get("/api/v1/menu-items/?status=bogus", headers=auth_headers)
+    assert response.status_code == 400
+
+
+async def test_response_includes_created_by(client: AsyncClient, auth_headers: dict, test_user):
+    resp = await client.post(
+        "/api/v1/menu-items/",
+        json={"name": "WithCreator", "body": "body"},
+        headers=auth_headers,
+    )
+    data = resp.json()
+    assert data["created_by"] == str(test_user.id)
+    assert data["updated_by"] == str(test_user.id)
 
 
 async def test_get_menu_item_by_id(client: AsyncClient, auth_headers: dict):
@@ -115,7 +183,7 @@ async def test_update_menu_item_partial(client: AsyncClient, auth_headers: dict)
     )
     assert response.status_code == 200
     assert response.json()["name"] == "Renamed"
-    assert response.json()["body"] == "original body"  # unchanged
+    assert response.json()["body"] == "original body"
 
 
 async def test_update_menu_item_not_found(client: AsyncClient, auth_headers: dict):
@@ -168,13 +236,10 @@ async def test_unarchive_not_found(client: AsyncClient, auth_headers: dict):
     assert response.status_code == 404
 
 
-async def test_update_other_users_item_returns_404(
-    client: AsyncClient, auth_headers: dict, session
+async def test_modify_other_users_item_returns_403(
+    client: AsyncClient, auth_headers: dict, session: AsyncSession
 ):
-    """Users cannot modify menu items they don't own."""
-    from app.auth.jwt import create_test_token
-    from app.models.user import User
-
+    """Users cannot modify menu items they don't own — returns 403."""
     created = await client.post(
         "/api/v1/menu-items/",
         json={"name": "Private", "body": "owner only"},
@@ -197,12 +262,12 @@ async def test_update_other_users_item_returns_404(
         await client.patch(
             f"/api/v1/menu-items/{item_id}", json={"name": "Hacked"}, headers=other_headers
         )
-    ).status_code == 404
+    ).status_code == 403
 
     assert (
         await client.patch(f"/api/v1/menu-items/{item_id}/archive", headers=other_headers)
-    ).status_code == 404
+    ).status_code == 403
 
     assert (
         await client.patch(f"/api/v1/menu-items/{item_id}/unarchive", headers=other_headers)
-    ).status_code == 404
+    ).status_code == 403

--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -17,7 +17,7 @@ const MealPlanReorder = dynamic(() => import("@/components/meal-plan-reorder"));
 type Mode = "select" | "reorder";
 
 export default function MealPlanEditPage() {
-  const { appUser } = useRequiredAuth();
+  useRequiredAuth();
   const router = useRouter();
   const queryClient = useQueryClient();
   const [mode, setMode] = useState<Mode>("select");
@@ -28,7 +28,7 @@ export default function MealPlanEditPage() {
   const { data: menuItems, isLoading: menuItemsLoading } = $api.useQuery(
     "get",
     "/api/v1/menu-items/",
-    { params: { query: { status: "active", created_by: appUser.id } } },
+    { params: { query: { status: "active" } } },
     { staleTime: 0 },
   );
 

--- a/ui/lib/api/schema.d.ts
+++ b/ui/lib/api/schema.d.ts
@@ -473,6 +473,16 @@ export interface components {
             /** Status */
             status: string;
             /**
+             * Created By
+             * Format: uuid
+             */
+            created_by: string;
+            /**
+             * Updated By
+             * Format: uuid
+             */
+            updated_by: string;
+            /**
              * Created At
              * Format: date-time
              */
@@ -888,7 +898,6 @@ export interface operations {
         parameters: {
             query?: {
                 status?: string;
-                created_by?: string | null;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## Summary

- `GET /menu-items/` now requires auth and implicitly scopes to the current user (drop `created_by` query param)
- Ownership denial returns 403 (fetch-then-authorize) instead of 404 (scoped query)
- `status` query param validated against enum (`active`, `archived`) — rejects invalid values with 400
- Support comma-separated multi-status filtering: `?status=active,archived`
- `MenuItemResponse` now includes `created_by` and `updated_by` UUIDs
- Frontend `meal-plan/edit` page no longer passes `created_by` (implicit from auth)

## Test plan

- [x] All 18 menu-items unit tests pass
- [x] Full backend test suite passes (0 failures)
- [x] Backend lint passes
- [x] Frontend lint passes
- [ ] Manual: `/meal-plan/edit` shows only your items
- [ ] Manual: `?status=active,archived` returns both
- [ ] Manual: `?status=bogus` returns 400
- [ ] Manual: PATCH someone else's item returns 403