### PR TITLE
feat(ui): stable 3-group sort + archived items on meal-plan edit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ ui/        — Frontend (Next.js + React + Tailwind)
 
 ## Important Principles
 
-- **Never justify cutting corners (security, architecture, best practices) by citing project size, user count, or cost or any excuse. Do things the right way.
+- **Never justify cutting corners (security, architecture, best practices) by citing project size, user count, or cost or any excuse. Do things the right way. Never ever justify this with small app, poc, locally usable etc.
 - **Secrets are secrets.** Store them in proper secret management (Secret Manager, or some XYZ vault), not plaintext env vars. This applies regardless of who has access today.
 - **Each system owns only its secrets.** GitHub Secrets hold only what CI needs. Cloud Run / Secret Manager hold only what runtime needs. No duplication.
 - **Never run migrations manually against production.** Migrations run via GitHub Actions on deploy. Only run locally against dev/test databases.

--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -28,7 +28,7 @@ export default function MealPlanEditPage() {
   const { data: menuItems, isLoading: menuItemsLoading } = $api.useQuery(
     "get",
     "/api/v1/menu-items/",
-    { params: { query: { status: "active" } } },
+    { params: { query: { status: "active,archived" } } },
     { staleTime: 0 },
   );
 
@@ -51,18 +51,53 @@ export default function MealPlanEditPage() {
     { id: string; name: string }[] | null
   >(null);
 
+  const archivedIds = useMemo(() => {
+    if (!menuItems) return new Set<string>();
+    return new Set(menuItems.filter((i) => i.status === "archived").map((i) => i.id));
+  }, [menuItems]);
+
+  const sortedItems = useMemo(() => {
+    if (!menuItems || !mealPlan) return [];
+
+    const planRank = new Map(
+      mealPlan.items.map((i) => [i.menu_item.id, i.rank]),
+    );
+
+    const inPlan: typeof menuItems = [];
+    const activeNotInPlan: typeof menuItems = [];
+    const archived: typeof menuItems = [];
+
+    for (const item of menuItems) {
+      if (planRank.has(item.id)) {
+        inPlan.push(item);
+      } else if (item.status === "active") {
+        activeNotInPlan.push(item);
+      } else {
+        archived.push(item);
+      }
+    }
+
+    inPlan.sort((a, b) => (planRank.get(a.id) ?? 0) - (planRank.get(b.id) ?? 0));
+    activeNotInPlan.sort(
+      (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+    );
+    archived.sort(
+      (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+    );
+
+    return [...inPlan, ...activeNotInPlan, ...archived];
+  }, [menuItems, mealPlan]);
+
   const filtered = useMemo(() => {
-    if (!menuItems) return [];
-    const items = [...menuItems].sort((a, b) => a.name.localeCompare(b.name));
-    if (!search) return items;
+    if (!search) return sortedItems;
     const q = search.toLowerCase();
-    return items.filter(
+    return sortedItems.filter(
       (i) =>
         i.name.toLowerCase().includes(q) || i.body.toLowerCase().includes(q),
     );
-  }, [menuItems, search]);
+  }, [sortedItems, search]);
 
-  const dataReady = !menuItemsLoading && !mealPlanLoading;
+  const dataReady = !menuItemsLoading && !mealPlanLoading && !!menuItems && !!mealPlan;
 
   function toggle(id: string) {
     const base = selected ?? initialIds;
@@ -91,11 +126,22 @@ export default function MealPlanEditPage() {
     setSaving(true);
     setError("");
 
+    const toUnarchive = orderedItems.filter((i) => archivedIds.has(i.id));
+    for (const item of toUnarchive) {
+      const { error: unarchiveError } = await apiClient.PATCH(
+        "/api/v1/menu-items/{item_id}/unarchive",
+        { params: { path: { item_id: item.id } } },
+      );
+      if (unarchiveError) {
+        setError("Failed to unarchive items. Please try again.");
+        setSaving(false);
+        return;
+      }
+    }
+
     const { error: apiError } = await apiClient.PUT(
       "/api/v1/meal-plans",
-      {
-        body: { menu_item_ids: orderedItems.map((i) => i.id) },
-      },
+      { body: { menu_item_ids: orderedItems.map((i) => i.id) } },
     );
 
     if (apiError) {
@@ -104,9 +150,8 @@ export default function MealPlanEditPage() {
       return;
     }
 
-    await queryClient.invalidateQueries({
-      queryKey: ["get", "/api/v1/meal-plans"],
-    });
+    await queryClient.invalidateQueries({ queryKey: ["get", "/api/v1/meal-plans"] });
+    await queryClient.invalidateQueries({ queryKey: ["get", "/api/v1/menu-items/"] });
     router.replace("/meal-plan");
   }
 
@@ -152,6 +197,7 @@ export default function MealPlanEditPage() {
                     name={item.name}
                     mode="select"
                     checked={current.has(item.id)}
+                    archived={archivedIds.has(item.id)}
                     onToggle={() => toggle(item.id)}
                     onTap={() => router.push(`/menu-items/${item.id}`)}
                   />

--- a/ui/components/meal-plan-item.tsx
+++ b/ui/components/meal-plan-item.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@/components/icon";
+import { cn } from "@/lib/utils";
 
 type Mode = "view" | "select";
 
@@ -6,6 +7,7 @@ interface MealPlanItemProps {
   name: string;
   mode: Mode;
   checked?: boolean;
+  archived?: boolean;
   onToggle?: () => void;
   onTap?: () => void;
 }
@@ -14,6 +16,7 @@ export function MealPlanItem({
   name,
   mode,
   checked,
+  archived,
   onToggle,
   onTap,
 }: MealPlanItemProps) {
@@ -24,7 +27,10 @@ export function MealPlanItem({
           onClick={onTap}
           className={`flex flex-1 items-center min-w-0 py-3 text-left active:bg-gray-100 ${mode === "select" ? "pl-3" : "pl-3 pr-3"}`}
         >
-          <span className="flex-1 min-w-0 text-2xl font-medium tracking-item leading-6 truncate">
+          <span className={cn(
+            "flex-1 min-w-0 text-2xl font-medium tracking-item leading-6 truncate",
+            archived && !checked && "line-through text-neutral-400",
+          )}>
             {name}
           </span>
           {mode === "view" && (
@@ -32,7 +38,11 @@ export function MealPlanItem({
           )}
         </button>
       ) : (
-        <span className={`flex-1 min-w-0 py-3 pr-3 text-2xl font-medium tracking-item leading-6 truncate ${mode === "view" ? "pl-3" : "pl-3"}`}>
+        <span className={cn(
+          "flex-1 min-w-0 py-3 pr-3 text-2xl font-medium tracking-item leading-6 truncate",
+          mode === "view" ? "pl-3" : "pl-3",
+          archived && !checked && "line-through text-neutral-400",
+        )}>
           {name}
         </span>
       )}


### PR DESCRIPTION
## Summary

- Menu items on `/meal-plan/edit` now display in a stable 3-group order: in-plan (by rank), active not-in-plan (by `updated_at` desc), archived (by `updated_at` desc with strikethrough)
- Toggling checkboxes does not re-sort the list
- Selecting an archived item removes the strikethrough; saving unarchives those items before updating the meal plan (fail-all semantics)

## Test plan

- [ ] `/meal-plan/edit` shows items in correct 3-group order
- [ ] Toggling checkboxes doesn't shuffle the list
- [ ] Archived items show strikethrough + dimmed text
- [ ] Selecting an archived item removes the strikethrough
- [ ] Save with a selected archived item → item gets unarchived + added to plan
- [ ] If unarchive fails, error shown, save aborted
- [ ] Search filters within the stable sort order