### PR TITLE
fix(ui): add fork_spoon icon to meal-plan header, make icons black

### DIFF
--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -165,7 +165,7 @@ export default function MealPlanEditPage() {
       <div className={`flex items-center border-b border-black ${mode === "select" ? "p-3" : ""}`}>
         {mode === "select" ? (
           <>
-            <Icon name="search" size={24} className="shrink-0 text-gray-300 mr-3" />
+            <Icon name="search" size={24} className="shrink-0 mr-3" />
             <input
               id="search"
               name="search"
@@ -179,7 +179,7 @@ export default function MealPlanEditPage() {
         ) : (
           <span className="flex items-center text-2xl font-bold tracking-label uppercase leading-6">
             <span className="flex items-center justify-center p-3 shrink-0">
-              <Icon name="check" size={24} className="text-gray-300" />
+              <Icon name="check" size={24} />
             </span>
             <span>{orderedItems?.length ?? 0} item(s)</span>
           </span>

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -28,6 +28,7 @@ export default function MealPlanPage() {
 
       <div className="flex items-stretch justify-between border-b border-black">
         <span className="flex items-center p-3 text-2xl font-bold tracking-label uppercase leading-6">
+          <Icon name="fork_spoon" size={24} className="shrink-0 mr-3" />
           Meal Plan
         </span>
         {ready && hasItems && (


### PR DESCRIPTION
## Summary

- Add `fork_spoon` icon before "Meal Plan" title on `/meal-plan`, matching the icon pattern on the edit page (search icon in select mode, check icon in reorder mode)
- Change edit page header icons from `text-gray-300` to black (default text color)

## Test plan

- [ ] `/meal-plan` shows fork_spoon icon before "Meal Plan" text
- [ ] `/meal-plan/edit` search icon is black
- [ ] `/meal-plan/edit` reorder mode check icon is black