### PR TITLE
perf(ui): remove Next.js built-in polyfills (14 KiB)

### DIFF
--- a/ui/lib/empty-polyfill.js
+++ b/ui/lib/empty-polyfill.js
@@ -1,0 +1,5 @@
+// Intentionally empty — disables Next.js's built-in polyfill-module.
+// All polyfilled features (Array.prototype.at, .flat, .flatMap, Object.fromEntries,
+// Object.hasOwn, String.prototype.trimStart/End) are natively supported by our
+// browserslist targets (last 2 versions of Chrome/Firefox/Safari/Edge/iOS).
+// See: https://github.com/vercel/next.js/issues/86785

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -41,7 +41,11 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
-  turbopack: {},
+  turbopack: {
+    resolveAlias: {
+      "../build/polyfills/polyfill-module": "./lib/empty-polyfill.js",
+    },
+  },
   experimental: {
     optimizePackageImports: ["@supabase/supabase-js", "@tanstack/react-query"],
   },


### PR DESCRIPTION
## Summary

Next.js unconditionally bundles `polyfill-module.js` containing polyfills for features already natively supported by all modern browsers:

- `Array.prototype.at` / `.flat` / `.flatMap`
- `Object.fromEntries` / `Object.hasOwn`
- `String.prototype.trimStart` / `.trimEnd`

This adds ~14 KiB of dead code to every production build regardless of browserslist config ([vercel/next.js#86785](https://github.com/vercel/next.js/issues/86785)).

**Fix:** Use `turbopack.resolveAlias` to redirect the polyfill module to an empty file. Verified the polyfill content is completely absent from the build output.

Approach validated by Expo's docs team who applied the same fix via webpack's `NormalModuleReplacementPlugin` ([expo/expo#43066](https://github.com/expo/expo/pull/43066)).

## Test plan

- [x] `bun run build` passes (all 16 routes)
- [x] `rg "Array.prototype.flat" .next/static/chunks/` returns 0 matches
- [x] ESLint + Vitest pass via pre-commit hooks
- [ ] Verify Vercel preview deployment works correctly
- [ ] Re-run Lighthouse — "Legacy JavaScript" audit should be resolved