### PR TITLE
fix(ui): add missing icons to Material Symbols font subset

### DIFF
--- a/ui/app/global-error.tsx
+++ b/ui/app/global-error.tsx
@@ -25,7 +25,7 @@ export default function GlobalError({
         />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=account_circle,add,arrow_back_ios_new,check,chevron_right,close,delete,drag_indicator,edit,fork_spoon,login,logout,more_horiz,open_in_new,receipt_long,search,settings&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=account_circle,add,arrow_back_ios_new,arrow_drop_down,arrow_drop_up,check,chevron_right,close,delete,description,drag_indicator,edit,expand_less,expand_more,fork_spoon,login,logout,more_horiz,open_in_new,receipt_long,search,settings,upload_file&display=swap"
         />
       </head>
       <body className="min-h-full flex flex-col font-mono bg-white text-black" style={{ fontFamily: "'JetBrains Mono', monospace" }}>

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=account_circle,add,arrow_back_ios_new,check,chevron_right,close,delete,drag_indicator,edit,fork_spoon,login,logout,more_horiz,open_in_new,receipt_long,search,settings&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=account_circle,add,arrow_back_ios_new,arrow_drop_down,arrow_drop_up,check,chevron_right,close,delete,description,drag_indicator,edit,expand_less,expand_more,fork_spoon,login,logout,more_horiz,open_in_new,receipt_long,search,settings,upload_file&display=swap"
         />
       </head>
       <body className="min-h-dvh flex flex-col font-mono bg-white text-black">


### PR DESCRIPTION
## Summary
- Audited all `<Icon name="...">` usages across the UI codebase
- Added 6 missing icons to the Google Fonts `icon_names` parameter: `arrow_drop_down`, `arrow_drop_up`, `description`, `expand_less`, `expand_more`, `upload_file`
- Updated both `layout.tsx` and `global-error.tsx`

## Missing icons found

| Icon | Used in |
|------|---------|
| `expand_less` | `app/(authenticated)/user/[id]/page.tsx` |
| `expand_more` | `app/(authenticated)/user/[id]/page.tsx` |
| `arrow_drop_down` | `app/(authenticated)/invoice/page.tsx` |
| `arrow_drop_up` | `app/(authenticated)/invoice/page.tsx` |
| `description` | `components/invoice-upload.tsx` |
| `upload_file` | `components/invoice-upload.tsx` |

## Test plan
- [ ] Verify expand/collapse toggle on user settings page renders icons correctly
- [ ] Verify show all/hide toggle on invoice list renders arrow icons
- [ ] Verify invoice upload component shows description/upload_file icons
- [ ] No regressions on other icons