### PR TITLE
feat(ui): View Transition API for directional navigation and shared elements

### DIFF
--- a/ui/app/(authenticated)/invoice/[id]/page.tsx
+++ b/ui/app/(authenticated)/invoice/[id]/page.tsx
@@ -130,7 +130,7 @@ export default function SplitAnalysisPage() {
     await apiClient.PATCH("/api/v1/orders/{order_id}/cancel", {
       params: { path: { order_id: id } },
     });
-    router.replace("/meal-plan");
+    router.replace("/meal-plan", { transitionTypes: ["nav-back"] });
   }
 
   async function handleApprove() {
@@ -141,7 +141,7 @@ export default function SplitAnalysisPage() {
         { params: { path: { order_id: id } } },
       );
       if (apiError) throw new Error((apiError as { detail?: string }).detail || "Approve failed");
-      router.push(`/invoice/${id}/result`);
+      router.push(`/invoice/${id}/result`, { transitionTypes: ["nav-forward"] });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Unknown error");
     } finally {

--- a/ui/app/(authenticated)/invoice/[id]/result/page.tsx
+++ b/ui/app/(authenticated)/invoice/[id]/result/page.tsx
@@ -61,7 +61,7 @@ export default function SplitResultPage() {
   if (isLoading) {
     return (
       <div className="flex flex-1 flex-col">
-        <TopBar showBack onBack={() => router.push("/meal-plan")} />
+        <TopBar showBack onBack={() => router.push("/meal-plan", { transitionTypes: ["nav-back"] })} />
         <div className="flex items-center p-3 border-b border-black">
           <span className="text-2xl font-bold tracking-label uppercase leading-6">
             Split result
@@ -119,7 +119,7 @@ export default function SplitResultPage() {
       </main>
 
       <button
-        onClick={() => router.push("/meal-plan")}
+        onClick={() => router.push("/meal-plan", { transitionTypes: ["nav-back"] })}
         className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white"
       >
         OK

--- a/ui/app/(authenticated)/invoice/page.tsx
+++ b/ui/app/(authenticated)/invoice/page.tsx
@@ -118,7 +118,7 @@ function InvoiceSetupContent() {
         }
 
         const order = await orderResp.json();
-        router.push(`/invoice/${order.id}`);
+        router.push(`/invoice/${order.id}`, { transitionTypes: ["nav-forward"] });
       } else if (file) {
         // Invoice flow: existing multipart upload
         const participantIds = [appUser.id, ...selectedOthers];
@@ -138,7 +138,7 @@ function InvoiceSetupContent() {
         }
 
         const data = await resp.json();
-        router.push(`/invoice/${data.id}`);
+        router.push(`/invoice/${data.id}`, { transitionTypes: ["nav-forward"] });
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Unknown error");
@@ -149,7 +149,7 @@ function InvoiceSetupContent() {
 
   return (
     <div className="flex flex-1 flex-col">
-      <TopBar showBack onBack={() => router.push("/meal-plan")} />
+      <TopBar showBack onBack={() => router.push("/meal-plan", { transitionTypes: ["nav-back"] })} />
 
       {/* Expense heading */}
       <div className="flex items-center p-3 border-b border-black">
@@ -230,7 +230,7 @@ function InvoiceSetupContent() {
           message={error}
           onDismiss={() => {
             setError(null);
-            router.replace("/meal-plan");
+            router.replace("/meal-plan", { transitionTypes: ["nav-back"] });
           }}
         />
       )}

--- a/ui/app/(authenticated)/layout.tsx
+++ b/ui/app/(authenticated)/layout.tsx
@@ -44,11 +44,13 @@ export default function AuthenticatedLayout({
         enter={{
           "nav-forward": "slide-forward",
           "nav-back": "slide-back",
+          "mode-switch": "auto",
           default: "none",
         }}
         exit={{
           "nav-forward": "slide-forward",
           "nav-back": "slide-back",
+          "mode-switch": "auto",
           default: "none",
         }}
         default="none"

--- a/ui/app/(authenticated)/layout.tsx
+++ b/ui/app/(authenticated)/layout.tsx
@@ -2,6 +2,8 @@
 
 import { useAuth } from "@/lib/auth";
 import { Spinner } from "@/components/spinner";
+import { ViewTransition } from "react";
+import { usePathname } from "next/navigation";
 
 export default function AuthenticatedLayout({
   children,
@@ -9,6 +11,7 @@ export default function AuthenticatedLayout({
   children: React.ReactNode;
 }) {
   const { appUser, loading, error, refreshAppUser } = useAuth();
+  const pathname = usePathname();
 
   if (loading || (!appUser && !error)) {
     return (
@@ -34,5 +37,24 @@ export default function AuthenticatedLayout({
     );
   }
 
-  return <div className="flex flex-1 flex-col">{children}</div>;
+  return (
+    <div className="flex flex-1 flex-col">
+      <ViewTransition
+        key={pathname}
+        enter={{
+          "nav-forward": "slide-forward",
+          "nav-back": "slide-back",
+          default: "none",
+        }}
+        exit={{
+          "nav-forward": "slide-forward",
+          "nav-back": "slide-back",
+          default: "none",
+        }}
+        default="none"
+      >
+        {children}
+      </ViewTransition>
+    </div>
+  );
 }

--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -152,7 +152,7 @@ export default function MealPlanEditPage() {
 
     await queryClient.invalidateQueries({ queryKey: ["get", "/api/v1/meal-plans"] });
     await queryClient.invalidateQueries({ queryKey: ["get", "/api/v1/menu-items/"] });
-    router.replace("/meal-plan");
+    router.replace("/meal-plan", { transitionTypes: ["nav-back"] });
   }
 
   return (
@@ -199,8 +199,7 @@ export default function MealPlanEditPage() {
                     checked={current.has(item.id)}
                     archived={archivedIds.has(item.id)}
                     onToggle={() => toggle(item.id)}
-                    onTap={() => router.push(`/menu-items/${item.id}`)}
-                  />
+                    onTap={() => router.push(`/menu-items/${item.id}`, { transitionTypes: ["nav-forward"] })}                  />
                 ))}
               </ul>
               {filtered.length === 0 && (
@@ -222,7 +221,7 @@ export default function MealPlanEditPage() {
 
       {mode === "select" && (
         <button
-          onClick={() => router.push("/menu-items/new")}
+          onClick={() => router.push("/menu-items/new", { transitionTypes: ["nav-forward"] })}
           aria-label="New menu item"
           className="fixed bottom-24 right-12 flex h-14 w-14 items-center justify-center bg-black text-white shadow-[4px_4px_0_rgba(0,0,0,0.2)]"
         >

--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -152,7 +152,7 @@ export default function MealPlanEditPage() {
 
     await queryClient.invalidateQueries({ queryKey: ["get", "/api/v1/meal-plans"] });
     await queryClient.invalidateQueries({ queryKey: ["get", "/api/v1/menu-items/"] });
-    router.replace("/meal-plan", { transitionTypes: ["nav-back"] });
+    router.replace("/meal-plan", { transitionTypes: ["mode-switch"] });
   }
 
   return (
@@ -194,12 +194,14 @@ export default function MealPlanEditPage() {
                 {filtered.map((item) => (
                   <MealPlanItem
                     key={item.id}
+                    id={item.id}
                     name={item.name}
                     mode="select"
                     checked={current.has(item.id)}
                     archived={archivedIds.has(item.id)}
                     onToggle={() => toggle(item.id)}
-                    onTap={() => router.push(`/menu-items/${item.id}`, { transitionTypes: ["nav-forward"] })}                  />
+                    onTap={() => router.push(`/menu-items/${item.id}`, { transitionTypes: ["nav-forward"] })}
+                  />
                 ))}
               </ul>
               {filtered.length === 0 && (

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -32,7 +32,7 @@ export default function MealPlanPage() {
           Meal Plan
         </span>
         {ready && hasItems && (
-          <button onClick={() => router.push("/meal-plan/edit", { transitionTypes: ["nav-forward"] })} aria-label="Edit meal plan" className="flex items-center justify-center p-3 bg-black">
+          <button onClick={() => router.push("/meal-plan/edit", { transitionTypes: ["mode-switch"] })} aria-label="Edit meal plan" className="flex items-center justify-center p-3 bg-black">
             <Icon name="edit" size={24} className="text-white" />
           </button>
         )}
@@ -43,7 +43,7 @@ export default function MealPlanPage() {
       >
         {!ready ? <Spinner /> : !hasItems ? (
           <button
-            onClick={() => router.push("/meal-plan/edit", { transitionTypes: ["nav-forward"] })}
+            onClick={() => router.push("/meal-plan/edit", { transitionTypes: ["mode-switch"] })}
             aria-label="Create meal plan"
             className="flex h-14 w-14 items-center justify-center bg-black text-white text-4xl shadow-[4px_4px_0_rgba(0,0,0,0.2)]"
           >
@@ -54,6 +54,7 @@ export default function MealPlanPage() {
             {items.map((item) => (
               <MealPlanItem
                 key={item.menu_item.id}
+                id={item.menu_item.id}
                 name={item.menu_item.name}
                 mode="view"
                 onTap={() =>

--- a/ui/app/(authenticated)/meal-plan/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/page.tsx
@@ -32,7 +32,7 @@ export default function MealPlanPage() {
           Meal Plan
         </span>
         {ready && hasItems && (
-          <button onClick={() => router.push("/meal-plan/edit")} aria-label="Edit meal plan" className="flex items-center justify-center p-3 bg-black">
+          <button onClick={() => router.push("/meal-plan/edit", { transitionTypes: ["nav-forward"] })} aria-label="Edit meal plan" className="flex items-center justify-center p-3 bg-black">
             <Icon name="edit" size={24} className="text-white" />
           </button>
         )}
@@ -43,7 +43,7 @@ export default function MealPlanPage() {
       >
         {!ready ? <Spinner /> : !hasItems ? (
           <button
-            onClick={() => router.push("/meal-plan/edit")}
+            onClick={() => router.push("/meal-plan/edit", { transitionTypes: ["nav-forward"] })}
             aria-label="Create meal plan"
             className="flex h-14 w-14 items-center justify-center bg-black text-white text-4xl shadow-[4px_4px_0_rgba(0,0,0,0.2)]"
           >
@@ -57,7 +57,7 @@ export default function MealPlanPage() {
                 name={item.menu_item.name}
                 mode="view"
                 onTap={() =>
-                  router.push(`/menu-items/${item.menu_item.id}`)
+                  router.push(`/menu-items/${item.menu_item.id}`, { transitionTypes: ["nav-forward"] })
                 }
               />
             ))}
@@ -67,7 +67,7 @@ export default function MealPlanPage() {
 
       {ready && hasItems && (
         <button
-          onClick={() => router.push("/invoice")}
+          onClick={() => router.push("/invoice", { transitionTypes: ["nav-forward"] })}
           aria-label="New expense"
           className="fixed bottom-24 right-12 flex h-14 w-14 items-center justify-center bg-black text-white shadow-[4px_4px_0_rgba(0,0,0,0.2)]"
         >

--- a/ui/app/(authenticated)/user/[id]/page.tsx
+++ b/ui/app/(authenticated)/user/[id]/page.tsx
@@ -109,7 +109,7 @@ export default function UserPage() {
 
   return (
     <div className="flex flex-1 flex-col">
-      <TopBar showBack onBack={() => router.push("/meal-plan")} />
+      <TopBar showBack onBack={() => router.push("/meal-plan", { transitionTypes: ["nav-back"] })} />
 
       <div className="flex h-12 items-center border-b border-black">
         <span className="flex-1 p-3 text-2xl font-bold tracking-label uppercase leading-6">

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -56,18 +56,33 @@
   animation: none;
 }
 
+::view-transition-image-pair(.slide-forward),
+::view-transition-image-pair(.slide-back) {
+  overflow: hidden;
+}
+
+::view-transition-group(.meal-item) {
+  animation: none;
+}
+::view-transition-old(.meal-item) {
+  animation: none;
+}
+::view-transition-new(.meal-item) {
+  animation: none;
+}
+
 ::view-transition-old(.slide-forward) {
-  animation: 150ms ease-in both vt-fade-out, 300ms ease-in-out both vt-slide-to-left;
+  animation: 120ms ease-in both vt-fade-out, 250ms ease-in-out both vt-slide-to-left;
 }
 ::view-transition-new(.slide-forward) {
-  animation: 200ms ease-out 100ms both vt-fade-in, 300ms ease-in-out both vt-slide-from-right;
+  animation: 160ms ease-out 80ms both vt-fade-in, 250ms ease-in-out both vt-slide-from-right;
 }
 
 ::view-transition-old(.slide-back) {
-  animation: 150ms ease-in both vt-fade-out, 300ms ease-in-out both vt-slide-to-right;
+  animation: 120ms ease-in both vt-fade-out, 250ms ease-in-out both vt-slide-to-right;
 }
 ::view-transition-new(.slide-back) {
-  animation: 200ms ease-out 100ms both vt-fade-in, 300ms ease-in-out both vt-slide-from-left;
+  animation: 160ms ease-out 80ms both vt-fade-in, 250ms ease-in-out both vt-slide-from-left;
 }
 
 @keyframes vt-fade-in {

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -43,3 +43,63 @@
     @apply cursor-pointer;
   }
 }
+
+/* View Transitions */
+::view-transition-group(site-header) {
+  animation: none;
+  z-index: 100;
+}
+::view-transition-old(site-header) {
+  display: none;
+}
+::view-transition-new(site-header) {
+  animation: none;
+}
+
+::view-transition-old(.slide-forward) {
+  animation: 150ms ease-in both vt-fade-out, 300ms ease-in-out both vt-slide-to-left;
+}
+::view-transition-new(.slide-forward) {
+  animation: 200ms ease-out 100ms both vt-fade-in, 300ms ease-in-out both vt-slide-from-right;
+}
+
+::view-transition-old(.slide-back) {
+  animation: 150ms ease-in both vt-fade-out, 300ms ease-in-out both vt-slide-to-right;
+}
+::view-transition-new(.slide-back) {
+  animation: 200ms ease-out 100ms both vt-fade-in, 300ms ease-in-out both vt-slide-from-left;
+}
+
+@keyframes vt-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes vt-fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+@keyframes vt-slide-to-left {
+  from { transform: translateX(0); }
+  to { transform: translateX(-40px); }
+}
+@keyframes vt-slide-from-right {
+  from { transform: translateX(40px); }
+  to { transform: translateX(0); }
+}
+@keyframes vt-slide-to-right {
+  from { transform: translateX(0); }
+  to { transform: translateX(40px); }
+}
+@keyframes vt-slide-from-left {
+  from { transform: translateX(-40px); }
+  to { transform: translateX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }
+}

--- a/ui/components/meal-plan-item.tsx
+++ b/ui/components/meal-plan-item.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 type Mode = "view" | "select";
 
 interface MealPlanItemProps {
+  id?: string;
   name: string;
   mode: Mode;
   checked?: boolean;
@@ -13,6 +14,7 @@ interface MealPlanItemProps {
 }
 
 export function MealPlanItem({
+  id,
   name,
   mode,
   checked,
@@ -21,16 +23,22 @@ export function MealPlanItem({
   onTap,
 }: MealPlanItemProps) {
   return (
-    <li className="flex items-center border-b border-gray-200 last:border-b-0">
+    <li
+      className="flex items-center border-b border-gray-200 last:border-b-0"
+      style={id ? { viewTransitionName: `meal-item-${id}`, viewTransitionClass: "meal-item" } : undefined}
+    >
       {onTap ? (
         <button
           onClick={onTap}
           className={`flex flex-1 items-center min-w-0 py-3 text-left active:bg-gray-100 ${mode === "select" ? "pl-3" : "pl-3 pr-3"}`}
         >
-          <span className={cn(
-            "flex-1 min-w-0 text-2xl font-medium tracking-item leading-6 truncate",
-            archived && !checked && "line-through text-neutral-400",
-          )}>
+          <span
+            className={cn(
+              "flex-1 min-w-0 text-2xl font-medium tracking-item leading-6 truncate",
+              archived && !checked && "line-through text-neutral-400",
+            )}
+            style={id && mode === "view" ? { viewTransitionName: `menu-title-${id}` } : undefined}
+          >
             {name}
           </span>
           {mode === "view" && (

--- a/ui/components/menu-item-page.tsx
+++ b/ui/components/menu-item-page.tsx
@@ -27,8 +27,12 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
   // Mode
   const [editing, setEditing] = useState(isNew);
 
-  // Form state
-  const [name, setName] = useState("");
+  // Form state — seed name from meal-plan cache for instant display during morph
+  const [name, setName] = useState(() => {
+    if (!itemId) return "";
+    const cached = queryClient.getQueryData<{ items: { menu_item: { id: string; name: string } }[] }>(["get", "/api/v1/meal-plans"]);
+    return cached?.items.find((i) => i.menu_item.id === itemId)?.menu_item.name ?? "";
+  });
   const [body, setBody] = useState("");
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -263,18 +267,10 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
   }
 
   // Show more button only for existing saved items
-  const showMoreButton = !isNew;
+  const showMoreButton = !isNew && !!item;
 
-  if (!isNew && !item) {
-    return (
-      <div className="flex flex-1 flex-col">
-        <TopBar showBack onBack={handleBack} />
-        <main className="flex flex-1 items-center justify-center">
-          <Spinner />
-        </main>
-      </div>
-    );
-  }
+  // Still loading item data
+  const itemLoading = !isNew && !item;
 
   return (
     <div className="flex flex-1 flex-col [overflow-anchor:none]">
@@ -305,6 +301,7 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
             <h1
               ref={headingRef}
               className="flex-1 min-w-0 p-3 text-2xl font-bold tracking-heading leading-6 break-words"
+              style={itemId ? { viewTransitionName: `menu-title-${itemId}` } : undefined}
             >
               {name || "Untitled"}
             </h1>
@@ -380,20 +377,26 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
       </div>
 
       {/* Content */}
-      <main className={cn("flex-1 p-3", editing && "flex flex-col")}>
-        {editing ? (
-          <textarea
-            value={body}
-            onChange={(e) => handleFormChange("body", e.target.value)}
-            placeholder="Recipe..."
-            className="flex-1 w-full resize-none bg-transparent text-base font-medium leading-6 outline-none placeholder:text-gray-300"
-          />
-        ) : (
-          <article className="prose prose-sm max-w-none">
-            <Markdown>{body || "*No content yet*"}</Markdown>
-          </article>
-        )}
-      </main>
+      {itemLoading ? (
+        <main className="flex flex-1 items-center justify-center">
+          <Spinner />
+        </main>
+      ) : (
+        <main className={cn("flex-1 p-3", editing && "flex flex-col")}>
+          {editing ? (
+            <textarea
+              value={body}
+              onChange={(e) => handleFormChange("body", e.target.value)}
+              placeholder="Recipe..."
+              className="flex-1 w-full resize-none bg-transparent text-base font-medium leading-6 outline-none placeholder:text-gray-300"
+            />
+          ) : (
+            <article className="prose prose-sm max-w-none">
+              <Markdown>{body || "*No content yet*"}</Markdown>
+            </article>
+          )}
+        </main>
+      )}
 
       {/* Click outside to close more popup */}
       {moreOpen && (

--- a/ui/components/top-bar.tsx
+++ b/ui/components/top-bar.tsx
@@ -24,7 +24,7 @@ export function TopBar({ showBack = false, onBack, rightAction }: TopBarProps) {
 
   const defaultRight = appUser ? (
     <button
-      onClick={() => router.push("/me", { transitionTypes: ["nav-forward"] })}
+      onClick={() => router.push(`/user/${appUser.id}`, { transitionTypes: ["nav-forward"] })}
       aria-label="Profile"
       className="flex h-full w-full items-center justify-center"
     >

--- a/ui/components/top-bar.tsx
+++ b/ui/components/top-bar.tsx
@@ -14,9 +14,17 @@ export function TopBar({ showBack = false, onBack, rightAction }: TopBarProps) {
   const router = useRouter();
   const { appUser } = useAuth();
 
+  function handleBack() {
+    if (onBack) {
+      onBack();
+    } else {
+      router.back();
+    }
+  }
+
   const defaultRight = appUser ? (
     <button
-      onClick={() => router.push("/me")}
+      onClick={() => router.push("/me", { transitionTypes: ["nav-forward"] })}
       aria-label="Profile"
       className="flex h-full w-full items-center justify-center"
     >
@@ -33,7 +41,7 @@ export function TopBar({ showBack = false, onBack, rightAction }: TopBarProps) {
   ) : undefined;
 
   return (
-    <header className="flex items-stretch justify-between border-b border-black">
+    <header className="flex items-stretch justify-between border-b border-black" style={{ viewTransitionName: "site-header" }}>
       <div className="shrink-0">
         {showBack ? (
           <button onClick={onBack ?? (() => router.back())} aria-label="Go back" className="flex h-full items-center justify-center p-3 bg-black">

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -47,6 +47,7 @@ const nextConfig: NextConfig = {
     },
   },
   experimental: {
+    viewTransition: true,
     optimizePackageImports: ["@supabase/supabase-js", "@tanstack/react-query"],
   },
   allowedDevOrigins: ["lr602lw45l.taile1dca.ts.net"],


### PR DESCRIPTION
## Summary

- Implements the View Transition API using React's `<ViewTransition>` component and Next.js 16.2's experimental `viewTransition` flag
- Adds directional slide animations for forward/back navigation (250ms ease-in-out with staggered fade)
- Shared element morphing: menu item title floats from list position to detail page header
- Mode-switch transitions: meal-plan ↔ edit uses browser default crossfade, keeping list items pinned in place
- Anchors TopBar header during all transitions (no movement)
- Respects `prefers-reduced-motion` by disabling all animation durations

## Key patterns

| Pattern | Transition type | Animation |
|---------|----------------|-----------|
| Forward navigation | `nav-forward` | Slide left + fade |
| Back navigation | `nav-back` | Slide right + fade |
| View ↔ Edit mode | `mode-switch` | Browser crossfade |
| Title morph | Shared `viewTransitionName` | Auto position/size morph |
| List items | Shared per-item name | `animation: none` (pinned) |
| Site header | Named element | `animation: none` (anchored) |

## Test plan

- [ ] Navigate meal-plan → menu-item: title morphs from list to header
- [ ] Navigate back: title morphs back to list position
- [ ] Navigate meal-plan → meal-plan/edit: items stay in place, surrounding UI crossfades
- [ ] Navigate meal-plan → invoice: directional slide left
- [ ] Browser back button: no directional animation (correct — no transition type)
- [ ] Profile avatar tap: forward slide to user page
- [ ] Enable "reduce motion" in OS settings: all animations instant
- [ ] First-time load of menu-item detail: title shows immediately (seeded from cache)
- [ ] Build passes with no errors