### PR TITLE
revert(ui): remove title morph view transition

### DIFF
--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -72,17 +72,17 @@
 }
 
 ::view-transition-old(.slide-forward) {
-  animation: 120ms ease-in both vt-fade-out, 250ms ease-in-out both vt-slide-to-left;
+  animation: 150ms ease-in both vt-fade-out, 250ms ease-in-out both vt-slide-to-left;
 }
 ::view-transition-new(.slide-forward) {
-  animation: 160ms ease-out 80ms both vt-fade-in, 250ms ease-in-out both vt-slide-from-right;
+  animation: 200ms ease-out 150ms both vt-fade-in, 250ms ease-in-out both vt-slide-from-right;
 }
 
 ::view-transition-old(.slide-back) {
-  animation: 120ms ease-in both vt-fade-out, 250ms ease-in-out both vt-slide-to-right;
+  animation: 150ms ease-in both vt-fade-out, 250ms ease-in-out both vt-slide-to-right;
 }
 ::view-transition-new(.slide-back) {
-  animation: 160ms ease-out 80ms both vt-fade-in, 250ms ease-in-out both vt-slide-from-left;
+  animation: 200ms ease-out 150ms both vt-fade-in, 250ms ease-in-out both vt-slide-from-left;
 }
 
 @keyframes vt-fade-in {

--- a/ui/components/meal-plan-item.tsx
+++ b/ui/components/meal-plan-item.tsx
@@ -37,7 +37,6 @@ export function MealPlanItem({
               "flex-1 min-w-0 text-2xl font-medium tracking-item leading-6 truncate",
               archived && !checked && "line-through text-neutral-400",
             )}
-            style={id && mode === "view" ? { viewTransitionName: `menu-title-${id}` } : undefined}
           >
             {name}
           </span>

--- a/ui/components/menu-item-page.tsx
+++ b/ui/components/menu-item-page.tsx
@@ -27,12 +27,8 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
   // Mode
   const [editing, setEditing] = useState(isNew);
 
-  // Form state — seed name from meal-plan cache for instant display during morph
-  const [name, setName] = useState(() => {
-    if (!itemId) return "";
-    const cached = queryClient.getQueryData<{ items: { menu_item: { id: string; name: string } }[] }>(["get", "/api/v1/meal-plans"]);
-    return cached?.items.find((i) => i.menu_item.id === itemId)?.menu_item.name ?? "";
-  });
+  // Form state
+  const [name, setName] = useState("");
   const [body, setBody] = useState("");
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -267,10 +263,18 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
   }
 
   // Show more button only for existing saved items
-  const showMoreButton = !isNew && !!item;
+  const showMoreButton = !isNew;
 
-  // Still loading item data
-  const itemLoading = !isNew && !item;
+  if (!isNew && !item) {
+    return (
+      <div className="flex flex-1 flex-col">
+        <TopBar showBack onBack={handleBack} />
+        <main className="flex flex-1 items-center justify-center">
+          <Spinner />
+        </main>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-1 flex-col [overflow-anchor:none]">
@@ -301,7 +305,6 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
             <h1
               ref={headingRef}
               className="flex-1 min-w-0 p-3 text-2xl font-bold tracking-heading leading-6 break-words"
-              style={itemId ? { viewTransitionName: `menu-title-${itemId}` } : undefined}
             >
               {name || "Untitled"}
             </h1>
@@ -377,26 +380,20 @@ export function MenuItemPage({ itemId }: MenuItemPageProps) {
       </div>
 
       {/* Content */}
-      {itemLoading ? (
-        <main className="flex flex-1 items-center justify-center">
-          <Spinner />
-        </main>
-      ) : (
-        <main className={cn("flex-1 p-3", editing && "flex flex-col")}>
-          {editing ? (
-            <textarea
-              value={body}
-              onChange={(e) => handleFormChange("body", e.target.value)}
-              placeholder="Recipe..."
-              className="flex-1 w-full resize-none bg-transparent text-base font-medium leading-6 outline-none placeholder:text-gray-300"
-            />
-          ) : (
-            <article className="prose prose-sm max-w-none">
-              <Markdown>{body || "*No content yet*"}</Markdown>
-            </article>
-          )}
-        </main>
-      )}
+      <main className={cn("flex-1 p-3", editing && "flex flex-col")}>
+        {editing ? (
+          <textarea
+            value={body}
+            onChange={(e) => handleFormChange("body", e.target.value)}
+            placeholder="Recipe..."
+            className="flex-1 w-full resize-none bg-transparent text-base font-medium leading-6 outline-none placeholder:text-gray-300"
+          />
+        ) : (
+          <article className="prose prose-sm max-w-none">
+            <Markdown>{body || "*No content yet*"}</Markdown>
+          </article>
+        )}
+      </main>
 
       {/* Click outside to close more popup */}
       {moreOpen && (


### PR DESCRIPTION
## Summary

- Removes the shared-element title morph that animated the menu item name from the meal-plan list to the detail page header
- Reverts the React Query cache seeding that was added to support instant morph display
- Restores the original early-return loading pattern in menu-item-page

## What's removed

- `viewTransitionName: menu-title-${id}` on the text span in `MealPlanItem`
- `viewTransitionName: menu-title-${itemId}` on the `<h1>` in `MenuItemPage`
- Cache-seeded `useState` initializer for the name field
- Restructured `itemLoading` conditional (back to early-return with TopBar + Spinner)

## What stays

- Directional slide animations (nav-forward/nav-back)
- Mode-switch crossfade (meal-plan ↔ edit)
- Meal-plan item pinning (`meal-item-${id}` with animation:none)
- Site header anchoring
- All transition types and CSS

## Test plan

- [ ] Navigate meal-plan → menu-item: normal directional slide, no title morph
- [ ] Menu-item detail shows spinner while loading (original behavior)
- [ ] All other view transitions still work as before
- [ ] Build passes