### PR TITLE
fix(ui): filename overflow, provider rename, always-show Next button

### DIFF
--- a/ui/app/(authenticated)/meal-plan/edit/page.tsx
+++ b/ui/app/(authenticated)/meal-plan/edit/page.tsx
@@ -235,14 +235,12 @@ export default function MealPlanEditPage() {
           <p className="p-3 text-xs text-red-600 tracking-wider bg-white border-t border-black">{error}</p>
         )}
         {mode === "select" ? (
-          isDirty && (
-            <button
-              onClick={handleNext}
-              className="flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white"
-            >
-              Next
-            </button>
-          )
+          <button
+            onClick={handleNext}
+            className="flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white"
+          >
+            Next
+          </button>
         ) : (
           <button
             onClick={handleSave}

--- a/ui/components/breadcrumb-nav.tsx
+++ b/ui/components/breadcrumb-nav.tsx
@@ -3,8 +3,8 @@
 import { useState, useRef, useEffect } from "react";
 
 const PROVIDERS: Record<string, { label: string; methods: string[] }> = {
-  swiggy: { label: "Swiggy", methods: ["order"] },
-  zomato: { label: "Zomato", methods: ["invoice"] },
+  swiggy: { label: "Instamart", methods: ["order"] },
+  zomato: { label: "Blinkit", methods: ["invoice"] },
 };
 
 const METHODS: Record<string, { label: string }> = {

--- a/ui/components/invoice-upload.tsx
+++ b/ui/components/invoice-upload.tsx
@@ -13,7 +13,7 @@ export function InvoiceUpload({ file, onFileChange }: InvoiceUploadProps) {
 
   return (
     <div className="flex items-stretch border-b border-gray-200">
-      <label className="flex items-center gap-3 p-3 flex-1 cursor-pointer">
+      <label className="flex items-center gap-3 p-3 flex-1 min-w-0 cursor-pointer">
         <Icon name={file ? "description" : "upload_file"} size={24} />
         <span className="text-base leading-6 truncate">
           {file ? file.name : "Invoice"}


### PR DESCRIPTION
## Summary

- **Filename overflow**: Add `min-w-0` to invoice upload label so long filenames truncate with ellipsis instead of pushing the delete button off-screen
- **Provider rename**: Display labels changed from Swiggy/Zomato to Instamart/Blinkit (internal keys unchanged)
- **Always-show Next**: Remove `isDirty` guard on the meal-plan edit page so the Next button is always visible, allowing users to proceed to reorder without changing the selection

## Test plan

- [ ] Upload a PDF with a very long filename on `/invoice` — verify truncation and delete button stays visible
- [ ] Confirm breadcrumb shows "Instamart" and "Blinkit" labels
- [ ] Navigate to `/meal-plan/edit` — verify Next button appears immediately without toggling any items