### PR TITLE
feat(ui): status-aware split review page (draft/completed/cancelled)

### DIFF
--- a/ui/app/(authenticated)/invoice/[id]/page.tsx
+++ b/ui/app/(authenticated)/invoice/[id]/page.tsx
@@ -118,9 +118,17 @@ export default function SplitAnalysisPage() {
       });
   }, [splitGroups, userMap, sortedNames]);
 
+  const isTerminal = order?.status === "completed" || order?.status === "cancelled";
+  const isCompleted = order?.status === "completed";
+  const isCancelled = order?.status === "cancelled";
+
   async function handleBack() {
     if (mode === "edit") {
       setMode("view");
+      return;
+    }
+    if (isTerminal) {
+      router.replace("/meal-plan");
       return;
     }
     const confirmed = window.confirm(
@@ -203,10 +211,13 @@ export default function SplitAnalysisPage() {
 
       {/* Status bar */}
       <div className="flex items-stretch justify-between border-b border-black">
-        <span className="flex items-center p-3 text-2xl font-bold tracking-label uppercase leading-6">
-          Split review
+        <span className="flex items-center gap-2 p-3 text-2xl font-bold tracking-label uppercase leading-6">
+          Split
+          {isCompleted && <Icon name="check_circle" size={24} className="text-green-600" />}
+          {isCancelled && <Icon name="close" size={24} className="text-red-600" />}
+          {!isTerminal && " review"}
         </span>
-        {mode === "view" && (
+        {!isTerminal && mode === "view" && (
           <button
             onClick={enterEditMode}
             aria-label="Edit split assignments"
@@ -219,7 +230,7 @@ export default function SplitAnalysisPage() {
 
       {/* Content */}
       <main className="flex-1">
-        {mode === "view" && sortedSplits.length > 0 && (
+        {(mode === "view" || isTerminal) && sortedSplits.length > 0 && (
           <div>
             {sortedSplits.map((group, gi) => (
               <div key={gi} className="border-b border-black last:border-b-0">
@@ -243,7 +254,7 @@ export default function SplitAnalysisPage() {
           </div>
         )}
 
-        {mode === "edit" && (
+        {!isTerminal && mode === "edit" && (
           <div>
             {allItems.map(({ item }) => (
               <div key={item.upc} className="border-b border-gray-200">
@@ -281,7 +292,25 @@ export default function SplitAnalysisPage() {
       </main>
 
       {/* Bottom button */}
-      {mode === "view" && (
+      {isCompleted && (
+        <button
+          onClick={() => router.push(`/invoice/${id}/result`)}
+          className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white"
+        >
+          Result
+        </button>
+      )}
+
+      {isCancelled && (
+        <button
+          onClick={() => router.push("/meal-plan")}
+          className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white"
+        >
+          OK
+        </button>
+      )}
+
+      {!isTerminal && mode === "view" && (
         <button
           onClick={handleApprove}
           disabled={submitting}
@@ -291,7 +320,7 @@ export default function SplitAnalysisPage() {
         </button>
       )}
 
-      {mode === "edit" && (
+      {!isTerminal && mode === "edit" && (
         <button
           onClick={handleConfirmEdits}
           disabled={submitting}

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=account_circle,add,arrow_back_ios_new,arrow_drop_down,arrow_drop_up,check,chevron_right,close,delete,description,drag_indicator,edit,expand_less,expand_more,fork_spoon,login,logout,more_horiz,open_in_new,receipt_long,search,settings,upload_file&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=account_circle,add,arrow_back_ios_new,arrow_drop_down,arrow_drop_up,check,check_circle,chevron_right,close,delete,description,drag_indicator,edit,expand_less,expand_more,fork_spoon,login,logout,more_horiz,open_in_new,receipt_long,search,settings,upload_file&display=swap"
         />
       </head>
       <body className="min-h-dvh flex flex-col font-mono bg-white text-black">


### PR DESCRIPTION
## Summary

Render the `/invoice/[id]` page based on order terminal state using Rx-style semantics:

- **draft** (active/hot) — mutable split review with edit + approve (existing behavior, unchanged)
- **completed** (terminal/complete) — read-only view with green `check_circle` icon, "Result" button navigates to split outcome page
- **cancelled** (terminal/error) — read-only view with red `close` icon, "OK" button returns to meal plan

Back button skips the cancel confirmation dialog for terminal orders since there's nothing to discard.

Also adds `check_circle` to the Material Symbols font subset.

## Test plan

- [ ] Create a new order → verify draft behavior unchanged (edit + approve)
- [ ] Approve an order → revisit `/invoice/[id]` → green checkmark, no edit button, "Result" CTA
- [ ] Cancel an order → revisit `/invoice/[id]` → red X, no edit button, "OK" CTA
- [ ] Back button on completed/cancelled orders navigates without confirmation dialog