### PR TITLE
fix(ui): fix disappearing Add button spinner and unify loading states

### DIFF
--- a/ui/app/(authenticated)/orders/[id]/expense/page.tsx
+++ b/ui/app/(authenticated)/orders/[id]/expense/page.tsx
@@ -314,9 +314,9 @@ export default function SplitAnalysisPage() {
         <button
           onClick={handleApprove}
           disabled={submitting}
-          className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:opacity-30"
+          className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:bg-neutral-400"
         >
-          {submitting ? "Splitting..." : "Split"}
+          {submitting ? <div className="size-6 animate-spin rounded-full border-[3px] border-white border-t-transparent" /> : "Split"}
         </button>
       )}
 
@@ -324,9 +324,9 @@ export default function SplitAnalysisPage() {
         <button
           onClick={handleConfirmEdits}
           disabled={submitting}
-          className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:opacity-30"
+          className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:bg-neutral-400"
         >
-          {submitting ? "Confirming..." : "Confirm"}
+          {submitting ? <div className="size-6 animate-spin rounded-full border-[3px] border-white border-t-transparent" /> : "Confirm"}
         </button>
       )}
 

--- a/ui/app/(authenticated)/orders/new/page.tsx
+++ b/ui/app/(authenticated)/orders/new/page.tsx
@@ -71,7 +71,7 @@ function InvoiceSetupContent() {
   }, [searchParams]);
 
   const canSubmit =
-    selectedOthers.length > 0 && (selectedOrderId || file) && !submitting;
+    selectedOthers.length > 0 && (selectedOrderId || file);
 
   async function handleSubmit() {
     if (!canSubmit || !session?.access_token) return;


### PR DESCRIPTION
## Summary
- Remove `!submitting` from `canSubmit` in orders/new — was causing the Add button to vanish during submission instead of showing a spinner
- Unify all action buttons (Add, Split, Confirm) to use consistent spinner + `disabled:bg-neutral-400` pattern

## Test plan
- [ ] Navigate to /orders/new, select participants + source, tap Add — button stays visible with spinner
- [ ] Navigate to /orders/[id]/expense (draft), tap Split — button shows spinner
- [ ] Enter edit mode, tap Confirm — button shows spinner
- [ ] All buttons show grey disabled background while submitting