### PR TITLE
feat(backend): automatic tracing via Logfire + Google Cloud Trace

### DIFF
--- a/backend/app/ai/client.py
+++ b/backend/app/ai/client.py
@@ -13,8 +13,13 @@ LLM providers. The model and provider are configured via Dynaconf settings:
 import json
 
 import litellm
+import logfire
+import structlog
+from opentelemetry import trace
 
 from app.config import settings
+
+logger = structlog.get_logger()
 
 
 def _model_string() -> str:
@@ -31,6 +36,7 @@ def _model_string() -> str:
     return f"{provider}/{model}"
 
 
+@logfire.instrument("llm_call {model}")
 async def generate(
     system: str,
     prompt: str,
@@ -46,22 +52,61 @@ async def generate(
     Returns:
         Parsed dict from the LLM's JSON response.
     """
-    response = await litellm.acompletion(
-        model=_model_string(),
-        messages=[
-            {"role": "system", "content": system},
-            {"role": "user", "content": prompt},
-        ],
-        response_format={
-            "type": "json_schema",
-            "json_schema": {
-                "name": "response",
-                "schema": schema,
-            },
-        },
-        api_base=settings.AI_BASE_URL or None,
-        api_key=settings.AI_API_KEY or None,
+    model = _model_string()
+
+    logger.info(
+        "llm_request",
+        model=model,
+        system_prompt=system,
+        user_prompt=prompt,
+        response_schema=schema,
     )
 
+    try:
+        response = await litellm.acompletion(
+            model=model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": prompt},
+            ],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "response",
+                    "schema": schema,
+                },
+            },
+            api_base=settings.AI_BASE_URL or None,
+            api_key=settings.AI_API_KEY or None,
+        )
+    except Exception as exc:
+        logger.info(
+            "llm_error",
+            model=model,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        raise
+
     content = response.choices[0].message.content
+
+    usage = getattr(response, "usage", None)
+    prompt_tokens = getattr(usage, "prompt_tokens", None)
+    completion_tokens = getattr(usage, "completion_tokens", None)
+    total_tokens = getattr(usage, "total_tokens", None)
+
+    current_span = trace.get_current_span()
+    if current_span.is_recording():
+        current_span.set_attribute("llm.prompt_tokens", prompt_tokens or 0)
+        current_span.set_attribute("llm.completion_tokens", completion_tokens or 0)
+
+    logger.info(
+        "llm_response",
+        model=model,
+        response_content=content,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+    )
+
     return json.loads(content)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,11 +8,13 @@ from app.logging import setup_logging
 from app.middleware.error_handler import register_error_handlers
 from app.middleware.request_logging import RequestLoggingMiddleware
 from app.routes import auth, meal_plans, menu_items, orders, users
+from app.tracing import setup_tracing
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     setup_logging()
+    setup_tracing(app)
     yield
 
 

--- a/backend/app/middleware/request_logging.py
+++ b/backend/app/middleware/request_logging.py
@@ -2,11 +2,13 @@
 Request logging middleware.
 
 Adds a request ID to every request and logs request/response details.
+Logs mutation request/response bodies for observability.
 """
 
 import time
 
 import structlog
+from opentelemetry import trace
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response
@@ -15,6 +17,19 @@ from app.logging import generate_request_id
 
 logger = structlog.get_logger()
 
+_MAX_BODY_BYTES = 10_240  # 10KB
+_MUTATION_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def _truncate_body(raw: bytes) -> str:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return f"<binary {len(raw)} bytes>"
+    if len(raw) > _MAX_BODY_BYTES:
+        return text[:_MAX_BODY_BYTES] + f"... (truncated, total {len(raw)} bytes)"
+    return text
+
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
@@ -22,11 +37,45 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(request_id=request_id)
 
+        current_span = trace.get_current_span()
+        if current_span.is_recording():
+            current_span.set_attribute("app.request_id", request_id)
+
+        if request.method in _MUTATION_METHODS:
+            content_type = request.headers.get("content-type", "")
+            if "multipart" in content_type:
+                logger.info(
+                    "request_body",
+                    body_type="multipart",
+                    content_type=content_type,
+                    content_length=request.headers.get("content-length"),
+                )
+            else:
+                body = await request.body()
+                if body:
+                    logger.info(
+                        "request_body",
+                        body_type="json",
+                        body=_truncate_body(body),
+                    )
+
         start = time.perf_counter()
 
         response = await call_next(request)
 
         elapsed_ms = round((time.perf_counter() - start) * 1000, 1)
+
+        if request.method in _MUTATION_METHODS and hasattr(response, "body_iterator"):
+            chunks = []
+            async for chunk in response.body_iterator:
+                if isinstance(chunk, str):
+                    chunks.append(chunk.encode("utf-8"))
+                else:
+                    chunks.append(chunk)
+            response_bytes = b"".join(chunks)
+            if response_bytes:
+                logger.info("response_body", body=_truncate_body(response_bytes))
+            response.body_iterator = iter([response_bytes])
 
         logger.info(
             "request",

--- a/backend/app/middleware/request_logging.py
+++ b/backend/app/middleware/request_logging.py
@@ -75,7 +75,11 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             response_bytes = b"".join(chunks)
             if response_bytes:
                 logger.info("response_body", body=_truncate_body(response_bytes))
-            response.body_iterator = iter([response_bytes])
+
+            async def _body_gen():
+                yield response_bytes
+
+            response.body_iterator = _body_gen()
 
         logger.info(
             "request",

--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -9,6 +9,8 @@ import uuid
 from collections import defaultdict
 from typing import Annotated
 
+import logfire
+import structlog
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
@@ -29,6 +31,7 @@ from app.services.split import compute_splits
 from app.services.storage import save_source_upload
 
 router = APIRouter(prefix="/orders", tags=["orders"])
+logger = structlog.get_logger()
 
 
 def _order_load_options():
@@ -189,68 +192,77 @@ async def create_order(
     this endpoint runs the full pipeline (extract → correlate → split).
     Idempotent: if an order already exists for this source, returns it.
     """
-    # Load source
-    source = await session.get(OrderSource, body.source_id)
-    if not source:
-        raise HTTPException(status_code=404, detail="Source not found")
-    if source.created_by != current_user.id:
-        raise HTTPException(status_code=403, detail="Not your source")
+    with logfire.span("pipeline", source_id=str(body.source_id), user_id=str(current_user.id)):
+        structlog.contextvars.bind_contextvars(source_id=str(body.source_id))
+        logger.info("pipeline_start", user_id=str(current_user.id))
 
-    # Idempotent: check if order already exists for this source
-    existing = await session.execute(
-        select(Order).where(Order.source_id == body.source_id).options(*_order_load_options())
-    )
-    existing_order = existing.scalar_one_or_none()
-    if existing_order:
-        return existing_order
+        # Load source
+        source = await session.get(OrderSource, body.source_id)
+        if not source:
+            raise HTTPException(status_code=404, detail="Source not found")
+        if source.created_by != current_user.id:
+            raise HTTPException(status_code=403, detail="Not your source")
 
-    # Ensure current user is included in participants
-    parsed_ids = list(body.participant_ids)
-    if current_user.id not in parsed_ids:
-        parsed_ids.append(current_user.id)
+        # Idempotent: check if order already exists for this source
+        existing = await session.execute(
+            select(Order).where(Order.source_id == body.source_id).options(*_order_load_options())
+        )
+        existing_order = existing.scalar_one_or_none()
+        if existing_order:
+            return existing_order
 
-    # Run extraction (uses checkpoint if available)
-    items = await run_extraction(session, source)
+        # Ensure current user is included in participants
+        parsed_ids = list(body.participant_ids)
+        if current_user.id not in parsed_ids:
+            parsed_ids.append(current_user.id)
 
-    # Build classified dict for compute_splits
-    item_total = sum(i["total"] for i in items if i["category"] == "item")
-    fee_total = sum(i["total"] for i in items if i["category"] == "fee")
-    classified = {
-        "summary": {
-            "item_total": item_total,
-            "fee_total": fee_total,
-            "grand_total": item_total + fee_total,
-        },
-        "items": items,
-    }
+        with logfire.span("extraction"):
+            items = await run_extraction(session, source)
 
-    # Snapshot meal plans
-    members, menu_items = await _snapshot_meal_plans(session, parsed_ids)
+        # Build classified dict for compute_splits
+        item_total = sum(i["total"] for i in items if i["category"] == "item")
+        fee_total = sum(i["total"] for i in items if i["category"] == "fee")
+        classified = {
+            "summary": {
+                "item_total": item_total,
+                "fee_total": fee_total,
+                "grand_total": item_total + fee_total,
+            },
+            "items": items,
+        }
 
-    # Correlate: which menu items use which grocery items
-    grocery_items = [i for i in items if i["category"] == "item"]
-    uses = await correlate(menu_items, grocery_items)
+        with logfire.span("snapshot_meal_plans"):
+            members, menu_items = await _snapshot_meal_plans(session, parsed_ids)
 
-    # Compute splits
-    result = compute_splits(classified, members, uses, str(current_user.id))
+        with logfire.span("correlate"):
+            grocery_items = [i for i in items if i["category"] == "item"]
+            uses = await correlate(menu_items, grocery_items)
 
-    # Create order + participants + splits in one commit
-    order = Order(
-        paid_by=current_user.id,
-        source_id=source.id,
-        snapshot={"members": members, "uses": uses, "menu_items": menu_items},
-        result=result,
-    )
-    session.add(order)
-    await session.flush()
+        with logfire.span("split"):
+            result = compute_splits(classified, members, uses, str(current_user.id))
 
-    for pid in parsed_ids:
-        session.add(OrderParticipant(order_id=order.id, user_id=pid))
+        with logfire.span("persist"):
+            order = Order(
+                paid_by=current_user.id,
+                source_id=source.id,
+                snapshot={"members": members, "uses": uses, "menu_items": menu_items},
+                result=result,
+            )
+            session.add(order)
+            await session.flush()
 
-    for split in _create_split_rows(order.id, result):
-        session.add(split)
+            structlog.contextvars.bind_contextvars(order_id=str(order.id))
 
-    await session.commit()
+            for pid in parsed_ids:
+                session.add(OrderParticipant(order_id=order.id, user_id=pid))
+
+            for split in _create_split_rows(order.id, result):
+                session.add(split)
+
+            await session.commit()
+
+        logger.info("pipeline_complete")
+
     return await _get_order_or_404(session, order.id)
 
 

--- a/backend/app/services/classify.py
+++ b/backend/app/services/classify.py
@@ -8,7 +8,12 @@ Classifies each extracted grocery item as "item" (product) or "fee"
 import json
 from collections.abc import Callable
 
+import logfire
+import structlog
+
 from app.ai.client import generate
+
+logger = structlog.get_logger()
 
 SYSTEM_PROMPT = (
     "You classify rows from a grocery invoice. "
@@ -24,6 +29,7 @@ CLASSIFY_SCHEMA = {
 }
 
 
+@logfire.instrument("classify_row")
 async def _classify_row(row: dict) -> str:
     """Classify a single row. Returns 'item' or 'fee'."""
     result = await generate(
@@ -34,6 +40,7 @@ async def _classify_row(row: dict) -> str:
     return result["category"]
 
 
+@logfire.instrument("classify {total_items} items")
 async def classify(
     extracted: dict,
     on_progress: Callable[[int, int, str, str], None] | None = None,
@@ -49,17 +56,39 @@ async def classify(
         Dict with "summary" and "items" keys.
     """
     all_rows = [row for invoice in extracted["invoices"] for row in invoice["items"]]
+    total_items = len(all_rows)
+
+    logger.info("classify_start", total_items=total_items)
 
     classified_rows = []
     for i, row in enumerate(all_rows, 1):
         category = await _classify_row(row)
         classified_rows.append({**row, "category": category})
+
+        logger.info(
+            "classify_row",
+            item_index=i,
+            total_items=total_items,
+            description=row["description"],
+            category_result=category,
+        )
+
         if on_progress:
-            on_progress(i, len(all_rows), category, row["description"])
+            on_progress(i, total_items, category, row["description"])
 
     item_total = round(sum(r["total"] for r in classified_rows if r["category"] == "item"), 2)
     fee_total = round(sum(r["total"] for r in classified_rows if r["category"] == "fee"), 2)
     grand_total = round(item_total + fee_total, 2)
+
+    items_count = sum(1 for r in classified_rows if r["category"] == "item")
+    fees_count = sum(1 for r in classified_rows if r["category"] == "fee")
+    logger.info(
+        "classify_complete",
+        items_count=items_count,
+        fees_count=fees_count,
+        item_total=item_total,
+        fee_total=fee_total,
+    )
 
     return {
         "summary": {

--- a/backend/app/services/correlate.py
+++ b/backend/app/services/correlate.py
@@ -6,7 +6,12 @@ alongside the full list of GroceryItems to the LLM, which returns the
 matched UPCs. This builds the bipartite adjacency used by the split service.
 """
 
+import logfire
+import structlog
+
 from app.ai.client import generate
+
+logger = structlog.get_logger()
 
 SYSTEM_PROMPT = (
     "You match a menu item to grocery items from an invoice. "
@@ -34,6 +39,7 @@ def _build_grocery_list_text(grocery_items: list[dict]) -> str:
     return "\n".join(f"- UPC: {g['upc']}, Description: {g['description']}" for g in grocery_items)
 
 
+@logfire.instrument("correlate_menu_item {menu_item_name}")
 async def _correlate_menu_item(
     menu_item_name: str,
     menu_item_body: str,
@@ -55,6 +61,7 @@ async def _correlate_menu_item(
     return result.get("matched_upcs", [])
 
 
+@logfire.instrument("correlate")
 async def correlate(
     menu_items: list[dict],
     grocery_items: list[dict],
@@ -69,9 +76,16 @@ async def correlate(
     Returns:
         Dict mapping menu_item_id (str) → list of matched UPC strings.
     """
+    logger.info(
+        "correlate_start",
+        total_menu_items=len(menu_items),
+        total_grocery_items=len(grocery_items),
+    )
+
     grocery_list_text = _build_grocery_list_text(grocery_items)
     valid_upcs = {g["upc"] for g in grocery_items}
     uses: dict[str, list[str]] = {}
+    total_matches = 0
 
     for item in menu_items:
         matched = await _correlate_menu_item(
@@ -79,6 +93,22 @@ async def correlate(
             menu_item_body=item["body"],
             grocery_list_text=grocery_list_text,
         )
-        uses[str(item["id"])] = [upc for upc in matched if upc in valid_upcs]
+        valid_matched = [upc for upc in matched if upc in valid_upcs]
+        uses[str(item["id"])] = valid_matched
+        total_matches += len(valid_matched)
+
+        logger.info(
+            "correlate_menu_item",
+            menu_item_name=item["name"],
+            matched_upcs_count=len(valid_matched),
+        )
+
+    unmatched = sum(1 for v in uses.values() if not v)
+    logger.info(
+        "correlate_complete",
+        total_menu_items=len(menu_items),
+        total_matches=total_matches,
+        unmatched_items=unmatched,
+    )
 
     return uses

--- a/backend/app/services/extract.py
+++ b/backend/app/services/extract.py
@@ -11,7 +11,11 @@ from async code.
 import dataclasses
 import re
 
+import logfire
 import pdfplumber
+import structlog
+
+logger = structlog.get_logger()
 
 
 @dataclasses.dataclass
@@ -98,6 +102,7 @@ def _parse_invoice_total(raw: str | None) -> float | None:
     return float(raw)
 
 
+@logfire.instrument("pdf_extract")
 def extract(pdf_path: str) -> dict:
     """Extract all invoice line items from a grocery invoice PDF.
 
@@ -110,10 +115,15 @@ def extract(pdf_path: str) -> dict:
     Returns:
         Dict with "invoices" key containing extracted data.
     """
+    logger.info("pdf_extract_start", file_path=pdf_path)
+
     invoices = []
+    pages_found = 0
+    tables_found = 0
 
     with pdfplumber.open(pdf_path) as pdf:
         for page_num, page in enumerate(pdf.pages, 1):
+            pages_found += 1
             for table in page.extract_tables():
                 if not table or len(table) < 2:
                     continue
@@ -124,6 +134,7 @@ def extract(pdf_path: str) -> dict:
                 if header_idx is None:
                     continue
 
+                tables_found += 1
                 header = table[header_idx]
                 upc_col = _col_index(header, "upc", "hsn code")
                 item_col = _col_index(header, "item description")
@@ -152,5 +163,13 @@ def extract(pdf_path: str) -> dict:
                         "invoice_total": invoice_total,
                     }
                 )
+
+    total_rows = sum(len(inv["items"]) for inv in invoices)
+    logger.info(
+        "pdf_extract_complete",
+        pages_found=pages_found,
+        tables_found=tables_found,
+        rows_extracted=total_rows,
+    )
 
     return {"invoices": invoices}

--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -23,7 +23,7 @@ async def run_extraction(session: AsyncSession, source: OrderSource) -> list[dic
     logger.info(
         "extraction_start",
         source_id=str(source.id),
-        source_type=source.type.value,
+        source_type=source.type.value if hasattr(source.type, "value") else source.type,
         checkpoint_hit=checkpoint_hit,
     )
 

--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -5,16 +5,30 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import logfire
+import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.order_source import OrderSource, OrderSourceType
 from app.services.extract import extract
 from app.services.storage import download_to_temp
 
+logger = structlog.get_logger()
 
+
+@logfire.instrument("run_extraction")
 async def run_extraction(session: AsyncSession, source: OrderSource) -> list[dict]:
     """Run extraction for a source, using its checkpoint if available."""
+    checkpoint_hit = source.items is not None
+    logger.info(
+        "extraction_start",
+        source_id=str(source.id),
+        source_type=source.type.value,
+        checkpoint_hit=checkpoint_hit,
+    )
+
     if source.items:
+        logger.info("extraction_checkpoint_used", items_count=len(source.items))
         return source.items
 
     if source.type == OrderSourceType.invoice:
@@ -26,6 +40,16 @@ async def run_extraction(session: AsyncSession, source: OrderSource) -> list[dic
 
     source.items = items
     await session.flush()
+
+    items_classified = sum(1 for i in items if i.get("category") == "item")
+    fees_count = sum(1 for i in items if i.get("category") == "fee")
+    logger.info(
+        "extraction_complete",
+        items_count=len(items),
+        items_classified=items_classified,
+        fees_count=fees_count,
+    )
+
     return items
 
 

--- a/backend/app/services/split.py
+++ b/backend/app/services/split.py
@@ -12,6 +12,11 @@ collapse into a single invocation.
 
 from collections import defaultdict
 
+import logfire
+import structlog
+
+logger = structlog.get_logger()
+
 # Type aliases
 MemberId = str
 MenuItemId = str
@@ -36,6 +41,7 @@ def build_grocery_to_members(members: Members, uses: Uses) -> dict[GroceryItemUp
     return grocery_to_members
 
 
+@logfire.instrument("compute_splits")
 def compute_splits(
     classified: dict,
     members: Members,
@@ -57,6 +63,15 @@ def compute_splits(
     Items with no member mapping are assigned to the payer only,
     ensuring the total of all splits equals the invoice total.
     """
+    grocery_items_count = sum(1 for i in classified["items"] if i["category"] == "item")
+    fees_count = sum(1 for i in classified["items"] if i["category"] == "fee")
+    logger.info(
+        "split_start",
+        members_count=len(members),
+        grocery_items_count=grocery_items_count,
+        fees_count=fees_count,
+    )
+
     all_members = sorted(members.keys())
     grocery_to_members = build_grocery_to_members(members, uses)
 
@@ -86,5 +101,7 @@ def compute_splits(
                 "splitEquallyAmong": sorted(member_set),
             }
         )
+
+    logger.info("split_complete", split_groups_count=len(splits))
 
     return {"paidBy": paid_by, "splits": splits}

--- a/backend/app/tracing.py
+++ b/backend/app/tracing.py
@@ -1,0 +1,44 @@
+"""OpenTelemetry tracing via Pydantic Logfire — no Logfire cloud."""
+
+import logfire
+
+from app.config import settings
+
+
+def setup_tracing(app) -> None:
+    """Configure tracing based on environment.
+
+    - Development: ConsoleSpanExporter (pretty-printed to stdout)
+    - Production: CloudTraceSpanExporter (Google Cloud Trace via ADC)
+    - Testing: disabled entirely
+    """
+    if not settings.get("TRACING_ENABLED", True):
+        logfire.configure(send_to_logfire=False)
+        return
+
+    exporter = settings.get("TRACING_EXPORTER", "console")
+    additional_processors = []
+
+    if exporter == "gcp":
+        from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        additional_processors.append(BatchSpanProcessor(CloudTraceSpanExporter()))
+
+    elif exporter == "console":
+        from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+        additional_processors.append(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+    logfire.configure(
+        send_to_logfire=False,
+        service_name=settings.TRACING_SERVICE_NAME,
+        additional_span_processors=additional_processors,
+    )
+
+    from app.database import engine
+
+    logfire.instrument_fastapi(app, excluded_urls="/health")
+    logfire.instrument_sqlalchemy(engine=engine)
+    logfire.instrument_httpx()
+    logfire.instrument_asyncpg()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "authlib>=1.3.0",
     "itsdangerous>=2.2.0",
     "python-dotenv>=1.2.2",
+    "logfire[fastapi,asyncpg,httpx]>=4.11.0",
+    "opentelemetry-exporter-gcp-trace>=1.8.0",
 ]
 
 [dependency-groups]

--- a/backend/settings.toml
+++ b/backend/settings.toml
@@ -9,6 +9,11 @@ AI_MODEL = "qwen2.5:3b"
 AI_BASE_URL = "http://localhost:11434"
 AI_API_KEY = ""
 
+# Tracing (Pydantic Logfire → OTel)
+TRACING_ENABLED = true
+TRACING_SERVICE_NAME = "cartwise-backend"
+TRACING_EXPORTER = "console"
+
 # Supabase — actual values in .secrets.toml (gitignored)
 SUPABASE_URL = ""
 SUPABASE_ANON_KEY = ""
@@ -58,6 +63,7 @@ DEBUG = true
 STORAGE_LOCAL = true
 SPLITWISE_ENABLED = true
 SESSION_SECRET_KEY = "test-session-secret"
+TRACING_ENABLED = false
 
 [production]
 # Real Splitwise — only production hits the actual API
@@ -67,4 +73,6 @@ SPLITWISE_OAUTH_BASE_URL = "https://secure.splitwise.com"
 AI_PROVIDER = "gemini"
 AI_MODEL = "gemini-3-flash-preview"
 AI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+# Tracing — export to Google Cloud Trace
+TRACING_EXPORTER = "gcp"
 # CORS_ORIGINS, FRONTEND_URL set via CARTWISE_* env vars

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -131,6 +131,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -190,6 +199,8 @@ dependencies = [
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "litellm" },
+    { name = "logfire", extra = ["asyncpg", "fastapi", "httpx"] },
+    { name = "opentelemetry-exporter-gcp-trace" },
     { name = "pdfplumber" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
@@ -219,6 +230,8 @@ requires-dist = [
     { name = "httpx", specifier = "==0.28.1" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "litellm", specifier = ">=1.83.7" },
+    { name = "logfire", extras = ["fastapi", "asyncpg", "httpx"], specifier = ">=4.11.0" },
+    { name = "opentelemetry-exporter-gcp-trace", specifier = ">=1.8.0" },
     { name = "pdfplumber", specifier = "==0.11.9" },
     { name = "pyjwt", specifier = "==2.12.1" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -559,6 +572,15 @@ wheels = [
 ]
 
 [[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.135.3"
 source = { registry = "https://pypi.org/simple" }
@@ -686,6 +708,69 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.50.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/18/238d7021d151bdab868f23433817b027dd759135202f4dfce0670d1230ca/google_auth-2.50.0.tar.gz", hash = "sha256:f35eafb191195328e8ce10a7883970877e7aeb49c2bfaa54aa0e394316d353d0", size = 336523, upload-time = "2026-04-30T21:19:29.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/cf/4880c2137c14280b2f59975cdf12cc442bc0ae1f9ea473a26eaa0c146786/google_auth-2.50.0-py3-none-any.whl", hash = "sha256:04382175e28b94f49694977f0a792688b59a668def1499e9d8de996dc9ce5b15", size = 246495, upload-time = "2026-04-30T21:19:27.664Z" },
+]
+
+[[package]]
+name = "google-cloud-trace"
+version = "1.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/7b/c2a5848c4722373c92b500b65e6308ad89ca0c7c01054e0d948c58c107f2/google_cloud_trace-1.19.0.tar.gz", hash = "sha256:58293c6efcee6c74bb854ff01b008823bef66845c14f15ffa5209d545098a65d", size = 103875, upload-time = "2026-03-26T22:18:18.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/91/0090acafa7d2caf1bf0d7222d42935e118164a539f9f9a00a814afa63fa1/google_cloud_trace-1.19.0-py3-none-any.whl", hash = "sha256:59604c4c775c40af31b367df6bada0af34518cc35ac8cfedecd43898a120c51d", size = 108454, upload-time = "2026-03-26T22:14:32.631Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
 name = "gotrue"
 version = "2.12.4"
 source = { registry = "https://pypi.org/simple" }
@@ -733,6 +818,41 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ed/105f619bdd00cb47a49aa2feea6232ea2bbb04199d52a22cc6a7d603b5cb/grpcio_status-1.80.0.tar.gz", hash = "sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd", size = 13901, upload-time = "2026-03-30T08:54:34.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/80/58cd2dfc19a07d022abe44bde7c365627f6c7cb6f692ada6c65ca437d09a/grpcio_status-1.80.0-py3-none-any.whl", hash = "sha256:4b56990363af50dbf2c2ebb80f1967185c07d87aa25aa2bea45ddb75fc181dbe", size = 14638, upload-time = "2026-03-30T08:54:01.569Z" },
 ]
 
 [[package]]
@@ -1108,6 +1228,35 @@ wheels = [
 ]
 
 [[package]]
+name = "logfire"
+version = "4.32.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "executing" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-sdk" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/d7/70c6def7f3f459b2d57aa7fb37863d31b8d877e391547f200ee8c31d2e30/logfire-4.32.1.tar.gz", hash = "sha256:8e7ff418b5f2629c8a8e9426283ff82c760a30f24516c4c389d6cbb1d9768c58", size = 1089612, upload-time = "2026-04-15T14:11:57.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/77/70f6d97d7d74d2f2eeb695fe491b28906ae5c350b48516bb237ace9a1778/logfire-4.32.1-py3-none-any.whl", hash = "sha256:cb7873efec0e94a3de6e603539daaa6509a454599621c80dd227fbfa0ade37d4", size = 313021, upload-time = "2026-04-15T14:11:54.024Z" },
+]
+
+[package.optional-dependencies]
+asyncpg = [
+    { name = "opentelemetry-instrumentation-asyncpg" },
+]
+fastapi = [
+    { name = "opentelemetry-instrumentation-fastapi" },
+]
+httpx = [
+    { name = "opentelemetry-instrumentation-httpx" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -1282,15 +1431,200 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.41.1"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-gcp-trace"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-cloud-trace" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-resourcedetector-gcp" },
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/55/32922e72d88421505383dfdba9c1ee6ad67253f94f2358f6e9dbc4ac3749/opentelemetry_exporter_gcp_trace-1.12.0.tar.gz", hash = "sha256:18c6e56fe123eed020d5005fdd819b196d64f651545bce1ca7e2e2cbaf9d343b", size = 18779, upload-time = "2026-04-28T20:59:41.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/68/c60e79992918eecb6de167e782c86946fdd5492bb163fe320f1a18959c3d/opentelemetry_exporter_gcp_trace-1.12.0-py3-none-any.whl", hash = "sha256:1538dab654bcb25e757ed34c94f27a2e30d90dc7deb3630f8d46d1111fcb3bad", size = 14013, upload-time = "2026-04-28T20:59:37.518Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/bc/1559d46557fe6eca0b46c88d4c2676285f1f3be2e8d06bb5d15fbffc814a/opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa", size = 20416, upload-time = "2026-03-04T14:17:23.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ca/8f122055c97a932311a3f640273f084e738008933503d0c2563cd5d591fc/opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149", size = 18369, upload-time = "2026-03-04T14:17:04.796Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/fa/73d50e2c15c56be4d000c98e24221d494674b0cc95524e2a8cb3856d95a4/opentelemetry_exporter_otlp_proto_http-1.40.0.tar.gz", hash = "sha256:db48f5e0f33217588bbc00274a31517ba830da576e59503507c839b38fa0869c", size = 17772, upload-time = "2026-03-04T14:17:25.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/3a/8865d6754e61c9fb170cdd530a124a53769ee5f740236064816eb0ca7301/opentelemetry_exporter_otlp_proto_http-1.40.0-py3-none-any.whl", hash = "sha256:a8d1dab28f504c5d96577d6509f80a8150e44e8f45f82cdbe0e34c99ab040069", size = 19960, upload-time = "2026-03-04T14:17:07.153Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/37/6bf8e66bfcee5d3c6515b79cb2ee9ad05fe573c20f7ceb288d0e7eeec28c/opentelemetry_instrumentation-0.61b0.tar.gz", hash = "sha256:cb21b48db738c9de196eba6b805b4ff9de3b7f187e4bbf9a466fa170514f1fc7", size = 32606, upload-time = "2026-03-04T14:20:16.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/3e/f6f10f178b6316de67f0dfdbbb699a24fbe8917cf1743c1595fb9dcdd461/opentelemetry_instrumentation-0.61b0-py3-none-any.whl", hash = "sha256:92a93a280e69788e8f88391247cc530fd81f16f2b011979d4d6398f805cfbc63", size = 33448, upload-time = "2026-03-04T14:19:02.447Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/3e/143cf5c034e58037307e6a24f06e0dd64b2c49ae60a965fc580027581931/opentelemetry_instrumentation_asgi-0.61b0.tar.gz", hash = "sha256:9d08e127244361dc33976d39dd4ca8f128b5aa5a7ae425208400a80a095019b5", size = 26691, upload-time = "2026-03-04T14:20:21.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/78/154470cf9d741a7487fbb5067357b87386475bbb77948a6707cae982e158/opentelemetry_instrumentation_asgi-0.61b0-py3-none-any.whl", hash = "sha256:e4b3ce6b66074e525e717efff20745434e5efd5d9df6557710856fba356da7a4", size = 16980, upload-time = "2026-03-04T14:19:10.894Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asyncpg"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/12/c704def946c66c1e039f2ebff9c8605f4d5a857a67acdfa5d0c3da0bb6b5/opentelemetry_instrumentation_asyncpg-0.61b0.tar.gz", hash = "sha256:a620bec93409e23335fac135231da0a16df705faab8521286a622fcc87666424", size = 8736, upload-time = "2026-03-04T14:20:22.918Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/ab/0d8ace084c87fa1156e7c8ad144e7867fbdeda3e15ff6c4c50c9e4730a13/opentelemetry_instrumentation_asyncpg-0.61b0-py3-none-any.whl", hash = "sha256:81039b94b3a0b014199cf7c2bd2753679fe600929620065619c13831e579a892", size = 10089, upload-time = "2026-03-04T14:19:14.6Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/35/aa727bb6e6ef930dcdc96a617b83748fece57b43c47d83ba8d83fbeca657/opentelemetry_instrumentation_fastapi-0.61b0.tar.gz", hash = "sha256:3a24f35b07c557ae1bbc483bf8412221f25d79a405f8b047de8b670722e2fa9f", size = 24800, upload-time = "2026-03-04T14:20:32.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/05/acfeb2cccd434242a0a7d0ea29afaf077e04b42b35b485d89aee4e0d9340/opentelemetry_instrumentation_fastapi-0.61b0-py3-none-any.whl", hash = "sha256:a1a844d846540d687d377516b2ff698b51d87c781b59f47c214359c4a241047c", size = 13485, upload-time = "2026-03-04T14:19:30.351Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/2a/e2becd55e33c29d1d9ef76e2579040ed1951cb33bacba259f6aff2fdd2a6/opentelemetry_instrumentation_httpx-0.61b0.tar.gz", hash = "sha256:6569ec097946c5551c2a4252f74c98666addd1bf047c1dde6b4ef426719ff8dd", size = 24104, upload-time = "2026-03-04T14:20:34.752Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/88/dde310dce56e2d85cf1a09507f5888544955309edc4b8d22971d6d3d1417/opentelemetry_instrumentation_httpx-0.61b0-py3-none-any.whl", hash = "sha256:dee05c93a6593a5dc3ae5d9d5c01df8b4e2c5d02e49275e5558534ee46343d5e", size = 17198, upload-time = "2026-03-04T14:19:33.585Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/77/dd38991db037fdfce45849491cb61de5ab000f49824a00230afb112a4392/opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd", size = 45667, upload-time = "2026-03-04T14:17:31.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/b2/189b2577dde745b15625b3214302605b1353436219d42b7912e77fa8dc24/opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f", size = 72073, upload-time = "2026-03-04T14:17:16.673Z" },
+]
+
+[[package]]
+name = "opentelemetry-resourcedetector-gcp"
+version = "1.12.0a0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/ae/b62c5e986c9c7f908a15682ea173bcfcdc00403c0c85243ccbd30eca7fc2/opentelemetry_resourcedetector_gcp-1.12.0a0.tar.gz", hash = "sha256:d5e3f78283a272eb92547e00bbeff45b7332a34ae791a70ab4eba81af9bc3baf", size = 18797, upload-time = "2026-04-28T20:59:43.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/84/9db2999adbc41505af3e6717e8d958746778cbfc9e07ed9c670bf9d1e6db/opentelemetry_resourcedetector_gcp-1.12.0a0-py3-none-any.whl", hash = "sha256:e803688d14e2969fe816077be81f7b034368314d485863f12ce49daba7c81919", size = 18798, upload-time = "2026-04-28T20:59:39.257Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252, upload-time = "2026-03-04T14:17:31.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951, upload-time = "2026-03-04T14:17:17.961Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/3c/f0196223efc5c4ca19f8fad3d5462b171ac6333013335ce540c01af419e9/opentelemetry_util_http-0.61b0.tar.gz", hash = "sha256:1039cb891334ad2731affdf034d8fb8b48c239af9b6dd295e5fabd07f1c95572", size = 11361, upload-time = "2026-03-04T14:20:57.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/e5/c08aaaf2f64288d2b6ef65741d2de5454e64af3e050f34285fb1907492fe/opentelemetry_util_http-0.61b0-py3-none-any.whl", hash = "sha256:8e715e848233e9527ea47e275659ea60a57a75edf5206a3b937e236a6da5fc33", size = 9281, upload-time = "2026-03-04T14:20:08.364Z" },
 ]
 
 [[package]]
@@ -1443,6 +1777,33 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
 name = "py-key-value-aio"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1465,6 +1826,27 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -2257,6 +2639,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replaces all manual `time.perf_counter()` instrumentation with **Pydantic Logfire** decorators (`@logfire.instrument`) and context managers (`logfire.span()`)
- Traces export to **Google Cloud Trace** in production (via `opentelemetry-exporter-gcp-trace`) and **console** in development
- **structlog domain events preserved** — traces handle timing waterfall, structlog handles business context (item counts, LLM prompts/responses, classification results)
- Adds request/response body logging for mutation endpoints in middleware

### Key changes

| File | Change |
|------|--------|
| `app/tracing.py` | **NEW** — configures Logfire exporters, instruments FastAPI/SQLAlchemy/httpx/asyncpg |
| `app/main.py` | Calls `setup_tracing(app)` in lifespan |
| `app/middleware/request_logging.py` | Attaches `request_id` to OTel span, logs mutation bodies |
| `app/ai/client.py` | `@logfire.instrument`, LLM token counts as span attributes |
| `app/services/{extract,classify,correlate,split,extraction}.py` | `@logfire.instrument` decorators, manual timing removed |
| `app/routes/orders.py` | Pipeline stages wrapped in `logfire.span()` contexts |
| `settings.toml` | `TRACING_ENABLED`, `TRACING_SERVICE_NAME`, `TRACING_EXPORTER` per env |
| `pyproject.toml` | Added `logfire[fastapi,asyncpg,httpx]`, `opentelemetry-exporter-gcp-trace` |

### Architecture

```
logfire.instrument_fastapi(app)     → auto-traces HTTP routes
logfire.instrument_sqlalchemy()     → auto-traces DB queries
logfire.instrument_httpx()          → auto-traces LiteLLM HTTP calls
logfire.instrument_asyncpg()        → auto-traces asyncpg driver

@logfire.instrument on pipeline:    extract → classify → correlate → split
logfire.span() in orders route:     pipeline > extraction > snapshot > correlate > split > persist

Export: console (dev) | Google Cloud Trace (prod) | disabled (test)
```

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] All modules import cleanly (`python -c "import app.tracing; ..."`)
- [x] Unit tests collect successfully (DB connection errors are expected without local stack)
- [ ] Start local dev server — verify console span output on order creation
- [ ] Deploy to Cloud Run — verify traces appear in Google Cloud Trace console
- [ ] Confirm Cloud Run SA has `roles/cloudtrace.agent`