### PR TITLE
fix(backend): add sqlalchemy extra to logfire dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "authlib>=1.3.0",
     "itsdangerous>=2.2.0",
     "python-dotenv>=1.2.2",
-    "logfire[fastapi,asyncpg,httpx]>=4.11.0",
+    "logfire[fastapi,sqlalchemy,asyncpg,httpx]>=4.11.0",
     "opentelemetry-exporter-gcp-trace>=1.8.0",
 ]
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -199,7 +199,7 @@ dependencies = [
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "litellm" },
-    { name = "logfire", extra = ["asyncpg", "fastapi", "httpx"] },
+    { name = "logfire", extra = ["asyncpg", "fastapi", "httpx", "sqlalchemy"] },
     { name = "opentelemetry-exporter-gcp-trace" },
     { name = "pdfplumber" },
     { name = "pyjwt" },
@@ -230,7 +230,7 @@ requires-dist = [
     { name = "httpx", specifier = "==0.28.1" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "litellm", specifier = ">=1.83.7" },
-    { name = "logfire", extras = ["fastapi", "asyncpg", "httpx"], specifier = ">=4.11.0" },
+    { name = "logfire", extras = ["fastapi", "sqlalchemy", "asyncpg", "httpx"], specifier = ">=4.11.0" },
     { name = "opentelemetry-exporter-gcp-trace", specifier = ">=1.8.0" },
     { name = "pdfplumber", specifier = "==0.11.9" },
     { name = "pyjwt", specifier = "==2.12.1" },
@@ -1255,6 +1255,9 @@ fastapi = [
 httpx = [
     { name = "opentelemetry-instrumentation-httpx" },
 ]
+sqlalchemy = [
+    { name = "opentelemetry-instrumentation-sqlalchemy" },
+]
 
 [[package]]
 name = "mako"
@@ -1562,6 +1565,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/2a/e2becd55e33c29d1d9ef76e2579040ed1951cb33bacba259f6aff2fdd2a6/opentelemetry_instrumentation_httpx-0.61b0.tar.gz", hash = "sha256:6569ec097946c5551c2a4252f74c98666addd1bf047c1dde6b4ef426719ff8dd", size = 24104, upload-time = "2026-03-04T14:20:34.752Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/88/dde310dce56e2d85cf1a09507f5888544955309edc4b8d22971d6d3d1417/opentelemetry_instrumentation_httpx-0.61b0-py3-none-any.whl", hash = "sha256:dee05c93a6593a5dc3ae5d9d5c01df8b4e2c5d02e49275e5558534ee46343d5e", size = 17198, upload-time = "2026-03-04T14:19:33.585Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-sqlalchemy"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/4f/3a325b180944610697a0a926d49d782b41a86120050d44fefb2715b630ac/opentelemetry_instrumentation_sqlalchemy-0.61b0.tar.gz", hash = "sha256:13a3a159a2043a52f0180b3757fbaa26741b0e08abb50deddce4394c118956e6", size = 15343, upload-time = "2026-03-04T14:20:47.648Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/97/b906a930c6a1a20c53ecc8b58cabc2cdd0ce560a2b5d44259084ffe4333e/opentelemetry_instrumentation_sqlalchemy-0.61b0-py3-none-any.whl", hash = "sha256:f115e0be54116ba4c327b8d7b68db4045ee18d44439d888ab8130a549c50d1c1", size = 14547, upload-time = "2026-03-04T14:19:53.088Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `sqlalchemy` to the logfire extras: `logfire[fastapi,sqlalchemy,asyncpg,httpx]`
- Fixes Cloud Run startup crash: `logfire.instrument_sqlalchemy()` requires `opentelemetry-instrumentation-sqlalchemy` which only comes from the `sqlalchemy` extra

## Context

The deploy from #154 failed because the container couldn't start — missing `opentelemetry.instrumentation.sqlalchemy` module.

## Test plan

- [x] `uv sync` resolves successfully with new extra
- [ ] Deploy to Cloud Run starts without crash