### PR TITLE
fix(ui): hide fee items from split edit mode

### DIFF
--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -242,9 +242,11 @@ async def create_order(
             result = compute_splits(classified, members, uses, str(current_user.id))
 
         with logfire.span("persist"):
+            is_no_split = result.get("noSplit", False)
             order = Order(
                 paid_by=current_user.id,
                 source_id=source.id,
+                status="no_split" if is_no_split else "draft",
                 snapshot={"members": members, "uses": uses, "menu_items": menu_items},
                 result=result,
             )
@@ -256,8 +258,9 @@ async def create_order(
             for pid in parsed_ids:
                 session.add(OrderParticipant(order_id=order.id, user_id=pid))
 
-            for split in _create_split_rows(order.id, result):
-                session.add(split)
+            if not is_no_split:
+                for split in _create_split_rows(order.id, result):
+                    session.add(split)
 
             await session.commit()
 
@@ -306,12 +309,12 @@ async def cancel_order(
     session: SessionDep,
     current_user: CurrentUser,
 ):
-    """Cancel a draft order. Only the payer can cancel."""
+    """Cancel a draft or no_split order. Only the payer can cancel."""
     order = await _get_order_or_404(session, order_id)
 
     if order.paid_by != current_user.id:
         raise HTTPException(status_code=403, detail="Only the payer can cancel this order")
-    if order.status != "draft":
+    if order.status not in ("draft", "no_split"):
         raise HTTPException(
             status_code=400, detail=f"Cannot cancel order with status '{order.status}'"
         )
@@ -328,12 +331,12 @@ async def edit_splits(
     session: SessionDep,
     current_user: CurrentUser,
 ):
-    """Edit split assignments for a draft order. Backend recomputes amounts."""
+    """Edit split assignments for a draft or no_split order. Backend recomputes amounts."""
     order = await _get_order_or_404(session, order_id)
 
     if order.paid_by != current_user.id:
         raise HTTPException(status_code=403, detail="Only the payer can edit splits")
-    if order.status != "draft":
+    if order.status not in ("draft", "no_split"):
         raise HTTPException(
             status_code=400, detail=f"Cannot edit splits for order with status '{order.status}'"
         )
@@ -341,24 +344,50 @@ async def edit_splits(
     if not order.result:
         raise HTTPException(status_code=400, detail="Order has no result data")
 
-    # Build a UPC→price lookup from the original classified items
-    all_items = order.result.get("splits", [])
-    upc_to_item: dict[str, dict] = {}
-    for split_group in all_items:
+    # Flatten all items from stored result, separate by category
+    all_items_flat: list[dict] = []
+    for split_group in order.result.get("splits", []):
         for item in split_group.get("groceryItems", []):
-            upc_to_item[item["upc"]] = item
+            all_items_flat.append(item)
 
-    # Group assignments by identical member set → recompute splits
+    fee_items = [i for i in all_items_flat if i.get("category") == "fee"]
+    non_fee_items = {i["upc"]: i for i in all_items_flat if i.get("category") != "fee"}
+    fee_upcs = {i["upc"] for i in fee_items}
+
+    # Reject fee UPCs in request
+    for assignment in data.assignments:
+        if assignment.upc in fee_upcs:
+            raise HTTPException(status_code=400, detail=f"Cannot assign fee item: {assignment.upc}")
+
+    # Validate all non-fee UPCs are present
+    request_upcs = {a.upc for a in data.assignments}
+    missing = set(non_fee_items.keys()) - request_upcs
+    if missing:
+        raise HTTPException(
+            status_code=400, detail=f"Missing assignments for UPCs: {sorted(missing)}"
+        )
+    unknown = request_upcs - set(non_fee_items.keys())
+    if unknown:
+        raise HTTPException(status_code=400, detail=f"Unknown UPC: {sorted(unknown)[0]}")
+
+    # Group non-fee items by member set, track members_with_items
+    members_with_items: set[str] = set()
     groups: dict[frozenset, list[dict]] = defaultdict(list)
     for assignment in data.assignments:
-        if assignment.upc not in upc_to_item:
-            raise HTTPException(status_code=400, detail=f"Unknown UPC: {assignment.upc}")
         member_key = (
             frozenset(assignment.member_ids)
             if assignment.member_ids
             else frozenset([str(order.paid_by)])
         )
-        groups[member_key].append(upc_to_item[assignment.upc])
+        groups[member_key].append(non_fee_items[assignment.upc])
+        members_with_items.update(member_key)
+
+    # Auto-assign fees to members who have items
+    fee_member_key = (
+        frozenset(members_with_items) if members_with_items else frozenset([str(order.paid_by)])
+    )
+    for fee_item in fee_items:
+        groups[fee_member_key].append(fee_item)
 
     # Delete old splits, create new ones
     for old_split in order.splits:
@@ -376,7 +405,11 @@ async def edit_splits(
             )
         )
 
+    # Auto-transition status based on post-condition
+    order.status = "no_split" if members_with_items <= {str(order.paid_by)} else "draft"
+
     await session.commit()
+    session.expunge_all()
     return await _get_order_or_404(session, order.id)
 
 

--- a/backend/app/services/split.py
+++ b/backend/app/services/split.py
@@ -57,11 +57,11 @@ def compute_splits(
         paid_by: The member who paid for the order.
 
     Returns:
-        Dict with "paidBy" and "splits" keys.
+        Dict with "paidBy", "splits", and "noSplit" keys.
 
-    Items with category "fee" are always split among all members.
-    Items with no member mapping are assigned to the payer only,
-    ensuring the total of all splits equals the invoice total.
+    Fees are split among members who have at least one non-fee item.
+    Items with no member mapping are assigned to the payer only.
+    noSplit is True when only the payer has items (no money moves).
     """
     grocery_items_count = sum(1 for i in classified["items"] if i["category"] == "item")
     fees_count = sum(1 for i in classified["items"] if i["category"] == "fee")
@@ -72,20 +72,25 @@ def compute_splits(
         fees_count=fees_count,
     )
 
-    all_members = sorted(members.keys())
     grocery_to_members = build_grocery_to_members(members, uses)
 
-    # Group grocery items by identical splitEquallyAmong sets
+    # Phase 1: process non-fee items, track which members have items
+    members_with_items: set[MemberId] = set()
     groups: dict[frozenset[MemberId], list[dict]] = defaultdict(list)
 
     for grocery_item in classified["items"]:
         if grocery_item["category"] == "fee":
-            neighbor_set = frozenset(all_members)
-        else:
-            matched = grocery_to_members.get(grocery_item["upc"])
-            neighbor_set = frozenset(matched) if matched else frozenset({paid_by})
-
+            continue
+        matched = grocery_to_members.get(grocery_item["upc"])
+        neighbor_set = frozenset(matched) if matched else frozenset({paid_by})
         groups[neighbor_set].append(grocery_item)
+        members_with_items.update(neighbor_set)
+
+    # Phase 2: assign fees to members who have at least one item
+    fee_members = frozenset(members_with_items) if members_with_items else frozenset({paid_by})
+    for grocery_item in classified["items"]:
+        if grocery_item["category"] == "fee":
+            groups[fee_members].append(grocery_item)
 
     # Each unique neighbor set = one split invocation
     splits = []
@@ -95,13 +100,20 @@ def compute_splits(
             {
                 "amount": amount,
                 "groceryItems": [
-                    {"upc": g["upc"], "description": g["description"], "total": g["total"]}
+                    {
+                        "upc": g["upc"],
+                        "description": g["description"],
+                        "total": g["total"],
+                        "category": g["category"],
+                    }
                     for g in grocery_items
                 ],
                 "splitEquallyAmong": sorted(member_set),
             }
         )
 
-    logger.info("split_complete", split_groups_count=len(splits))
+    no_split = members_with_items <= {paid_by}
 
-    return {"paidBy": paid_by, "splits": splits}
+    logger.info("split_complete", split_groups_count=len(splits), no_split=no_split)
+
+    return {"paidBy": paid_by, "splits": splits, "noSplit": no_split}

--- a/backend/tests/test_create_order_pipeline.py
+++ b/backend/tests/test_create_order_pipeline.py
@@ -36,10 +36,14 @@ async def test_create_order_pipeline(
     mock_uses = {}
     mock_result = {
         "paidBy": str(test_user.id),
+        "noSplit": True,
         "splits": [
             {
                 "amount": 60.0,
-                "groceryItems": [{"upc": "I1", "description": "Milk", "total": 50.0}],
+                "groceryItems": [
+                    {"upc": "I1", "description": "Milk", "total": 50.0, "category": "item"},
+                    {"upc": "FEE_DEL", "description": "Delivery", "total": 10.0, "category": "fee"},
+                ],
                 "splitEquallyAmong": [str(test_user.id)],
             }
         ],
@@ -70,9 +74,8 @@ async def test_create_order_pipeline(
     assert resp.status_code == 201
     data = resp.json()
     assert data["source_id"] == str(source.id)
-    assert data["status"] == "draft"
-    assert len(data["splits"]) == 1
-    assert data["splits"][0]["amount"] == 60.0
+    assert data["status"] == "no_split"
+    assert len(data["splits"]) == 0  # noSplit=True → no Split rows created
 
 
 async def test_create_order_idempotent(
@@ -120,10 +123,13 @@ async def test_create_order_adds_current_user_to_participants(
     ]
     mock_result = {
         "paidBy": str(test_user.id),
+        "noSplit": False,
         "splits": [
             {
                 "amount": 80.0,
-                "groceryItems": [{"upc": "I1", "description": "Rice", "total": 80.0}],
+                "groceryItems": [
+                    {"upc": "I1", "description": "Rice", "total": 80.0, "category": "item"},
+                ],
                 "splitEquallyAmong": [str(test_user.id), str(other.id)],
             }
         ],
@@ -163,18 +169,192 @@ async def test_create_order_edit_splits(
     """PUT /orders/{id}/splits recomputes split amounts from reassignments."""
     source = await _make_source(session, test_user.id)
 
+    other = User(email="o@x.com", name="O", oauth_provider="google", oauth_id="o-oauth")
+    session.add(other)
+    await session.flush()
+
     mock_items = [
         {"id": "I1", "name": "Milk", "quantity": 1, "total": 50.0, "category": "item"},
         {"id": "I2", "name": "Bread", "quantity": 1, "total": 30.0, "category": "item"},
+        {"id": "FEE", "name": "Delivery", "quantity": 1, "total": 10.0, "category": "fee"},
     ]
     mock_result = {
         "paidBy": str(test_user.id),
+        "noSplit": True,
         "splits": [
             {
-                "amount": 80.0,
+                "amount": 90.0,
                 "groceryItems": [
-                    {"upc": "I1", "description": "Milk", "total": 50.0},
-                    {"upc": "I2", "description": "Bread", "total": 30.0},
+                    {"upc": "I1", "description": "Milk", "total": 50.0, "category": "item"},
+                    {"upc": "I2", "description": "Bread", "total": 30.0, "category": "item"},
+                    {"upc": "FEE", "description": "Delivery", "total": 10.0, "category": "fee"},
+                ],
+                "splitEquallyAmong": [str(test_user.id)],
+            }
+        ],
+    }
+
+    with (
+        patch(
+            "app.routes.orders.run_extraction",
+            new_callable=AsyncMock,
+            return_value=mock_items,
+        ),
+        patch("app.routes.orders.correlate", new_callable=AsyncMock, return_value={}),
+        patch("app.routes.orders.compute_splits", return_value=mock_result),
+    ):
+        create_resp = await client.post(
+            "/api/v1/orders/",
+            headers=auth_headers,
+            json={
+                "source_id": str(source.id),
+                "participant_ids": [str(test_user.id), str(other.id)],
+            },
+        )
+
+    assert create_resp.status_code == 201
+    assert create_resp.json()["status"] == "no_split"
+    order_id = create_resp.json()["id"]
+
+    # Reassign Milk to other user — should transition to draft
+    edit_resp = await client.put(
+        f"/api/v1/orders/{order_id}/splits",
+        headers=auth_headers,
+        json={
+            "assignments": [
+                {"upc": "I1", "member_ids": [str(other.id)]},
+                {"upc": "I2", "member_ids": [str(test_user.id)]},
+            ]
+        },
+    )
+    assert edit_resp.status_code == 200
+    assert edit_resp.json()["status"] == "draft"
+    splits = edit_resp.json()["splits"]
+    # Two groups: other (Milk=50 + fee share) and payer (Bread=30 + fee share)
+    # Actually fees go to both members since both have items
+    total = sum(s["amount"] for s in splits)
+    assert total == 90.0
+
+
+async def test_create_order_no_split_status(
+    client: AsyncClient, auth_headers: dict, test_user, session: AsyncSession
+):
+    """Order with noSplit=False gets status='draft' and Split rows."""
+    source = await _make_source(session, test_user.id)
+
+    other = User(email="ns@x.com", name="NS", oauth_provider="google", oauth_id="ns-oauth")
+    session.add(other)
+    await session.flush()
+
+    mock_items = [
+        {"id": "I1", "name": "Milk", "quantity": 1, "total": 50.0, "category": "item"},
+    ]
+    mock_result = {
+        "paidBy": str(test_user.id),
+        "noSplit": False,
+        "splits": [
+            {
+                "amount": 50.0,
+                "groceryItems": [
+                    {"upc": "I1", "description": "Milk", "total": 50.0, "category": "item"},
+                ],
+                "splitEquallyAmong": [str(test_user.id), str(other.id)],
+            }
+        ],
+    }
+
+    with (
+        patch(
+            "app.routes.orders.run_extraction",
+            new_callable=AsyncMock,
+            return_value=mock_items,
+        ),
+        patch("app.routes.orders.correlate", new_callable=AsyncMock, return_value={}),
+        patch("app.routes.orders.compute_splits", return_value=mock_result),
+    ):
+        resp = await client.post(
+            "/api/v1/orders/",
+            headers=auth_headers,
+            json={
+                "source_id": str(source.id),
+                "participant_ids": [str(test_user.id), str(other.id)],
+            },
+        )
+
+    assert resp.status_code == 201
+    assert resp.json()["status"] == "draft"
+    assert len(resp.json()["splits"]) == 1
+    assert resp.json()["splits"][0]["amount"] == 50.0
+
+
+async def test_cancel_no_split_order(
+    client: AsyncClient, auth_headers: dict, test_user, session: AsyncSession
+):
+    """Can cancel an order with status='no_split'."""
+    source = await _make_source(session, test_user.id)
+
+    mock_items = [
+        {"id": "I1", "name": "Milk", "quantity": 1, "total": 50.0, "category": "item"},
+    ]
+    mock_result = {
+        "paidBy": str(test_user.id),
+        "noSplit": True,
+        "splits": [
+            {
+                "amount": 50.0,
+                "groceryItems": [
+                    {"upc": "I1", "description": "Milk", "total": 50.0, "category": "item"},
+                ],
+                "splitEquallyAmong": [str(test_user.id)],
+            }
+        ],
+    }
+
+    with (
+        patch(
+            "app.routes.orders.run_extraction",
+            new_callable=AsyncMock,
+            return_value=mock_items,
+        ),
+        patch("app.routes.orders.correlate", new_callable=AsyncMock, return_value={}),
+        patch("app.routes.orders.compute_splits", return_value=mock_result),
+    ):
+        create_resp = await client.post(
+            "/api/v1/orders/",
+            headers=auth_headers,
+            json={
+                "source_id": str(source.id),
+                "participant_ids": [str(test_user.id)],
+            },
+        )
+
+    assert create_resp.json()["status"] == "no_split"
+    order_id = create_resp.json()["id"]
+
+    cancel_resp = await client.patch(f"/api/v1/orders/{order_id}/cancel", headers=auth_headers)
+    assert cancel_resp.status_code == 200
+    assert cancel_resp.json()["status"] == "cancelled"
+
+
+async def test_edit_splits_rejects_fee_upc(
+    client: AsyncClient, auth_headers: dict, test_user, session: AsyncSession
+):
+    """Sending a fee UPC in assignments returns 400."""
+    source = await _make_source(session, test_user.id)
+
+    mock_items = [
+        {"id": "I1", "name": "Milk", "quantity": 1, "total": 50.0, "category": "item"},
+        {"id": "FEE", "name": "Delivery", "quantity": 1, "total": 10.0, "category": "fee"},
+    ]
+    mock_result = {
+        "paidBy": str(test_user.id),
+        "noSplit": True,
+        "splits": [
+            {
+                "amount": 60.0,
+                "groceryItems": [
+                    {"upc": "I1", "description": "Milk", "total": 50.0, "category": "item"},
+                    {"upc": "FEE", "description": "Delivery", "total": 10.0, "category": "fee"},
                 ],
                 "splitEquallyAmong": [str(test_user.id)],
             }
@@ -201,18 +381,74 @@ async def test_create_order_edit_splits(
 
     order_id = create_resp.json()["id"]
 
-    # Reassign items to different groups
     edit_resp = await client.put(
         f"/api/v1/orders/{order_id}/splits",
         headers=auth_headers,
         json={
             "assignments": [
                 {"upc": "I1", "member_ids": [str(test_user.id)]},
-                {"upc": "I2", "member_ids": [str(test_user.id)]},
+                {"upc": "FEE", "member_ids": [str(test_user.id)]},
             ]
         },
     )
-    assert edit_resp.status_code == 200
-    splits = edit_resp.json()["splits"]
-    assert len(splits) == 1
-    assert splits[0]["amount"] == 80.0
+    assert edit_resp.status_code == 400
+    assert "fee" in edit_resp.json()["detail"].lower()
+
+
+async def test_edit_splits_requires_all_non_fee_upcs(
+    client: AsyncClient, auth_headers: dict, test_user, session: AsyncSession
+):
+    """Omitting a non-fee UPC from assignments returns 400."""
+    source = await _make_source(session, test_user.id)
+
+    mock_items = [
+        {"id": "I1", "name": "Milk", "quantity": 1, "total": 50.0, "category": "item"},
+        {"id": "I2", "name": "Bread", "quantity": 1, "total": 30.0, "category": "item"},
+    ]
+    mock_result = {
+        "paidBy": str(test_user.id),
+        "noSplit": True,
+        "splits": [
+            {
+                "amount": 80.0,
+                "groceryItems": [
+                    {"upc": "I1", "description": "Milk", "total": 50.0, "category": "item"},
+                    {"upc": "I2", "description": "Bread", "total": 30.0, "category": "item"},
+                ],
+                "splitEquallyAmong": [str(test_user.id)],
+            }
+        ],
+    }
+
+    with (
+        patch(
+            "app.routes.orders.run_extraction",
+            new_callable=AsyncMock,
+            return_value=mock_items,
+        ),
+        patch("app.routes.orders.correlate", new_callable=AsyncMock, return_value={}),
+        patch("app.routes.orders.compute_splits", return_value=mock_result),
+    ):
+        create_resp = await client.post(
+            "/api/v1/orders/",
+            headers=auth_headers,
+            json={
+                "source_id": str(source.id),
+                "participant_ids": [str(test_user.id)],
+            },
+        )
+
+    order_id = create_resp.json()["id"]
+
+    # Only send I1, missing I2
+    edit_resp = await client.put(
+        f"/api/v1/orders/{order_id}/splits",
+        headers=auth_headers,
+        json={
+            "assignments": [
+                {"upc": "I1", "member_ids": [str(test_user.id)]},
+            ]
+        },
+    )
+    assert edit_resp.status_code == 400
+    assert "Missing" in edit_resp.json()["detail"]

--- a/backend/tests/test_pipeline_integration.py
+++ b/backend/tests/test_pipeline_integration.py
@@ -279,8 +279,8 @@ async def test_swiggy_pipeline_happy_path(
 
     assert order_resp.status_code == 201
     data = order_resp.json()
-    assert data["status"] == "draft"
-    assert len(data["splits"]) > 0
+    assert data["status"] == "no_split"
+    assert len(data["splits"]) == 0  # noSplit → no Split rows
     assert len(data["participants"]) == 2
 
     # Verify source was updated with raw API responses

--- a/backend/tests/test_split.py
+++ b/backend/tests/test_split.py
@@ -31,7 +31,7 @@ def test_build_grocery_to_members_menu_item_not_in_uses():
 # --- compute_splits ---
 
 
-async def test_compute_splits_groups_by_member_set():
+def test_compute_splits_groups_by_member_set():
     classified = {
         "items": [
             {"upc": "AAA", "description": "Item A", "total": 50.0, "category": "item"},
@@ -45,18 +45,20 @@ async def test_compute_splits_groups_by_member_set():
     result = compute_splits(classified, members, uses, "user-1")
 
     assert result["paidBy"] == "user-1"
+    assert result["noSplit"] is False
     assert len(result["splits"]) == 2
 
     splits_by_members = {tuple(s["splitEquallyAmong"]): s for s in result["splits"]}
 
     shared = splits_by_members[("user-1", "user-2")]
     assert shared["amount"] == 60.0  # 50 (AAA) + 10 (fee)
+    assert all("category" in g for g in shared["groceryItems"])
 
     solo = splits_by_members[("user-2",)]
     assert solo["amount"] == 50.0
 
 
-async def test_compute_splits_unmatched_items_go_to_payer():
+def test_compute_splits_unmatched_items_go_to_payer():
     """Unmatched items are assigned to the payer, not dropped."""
     classified = {
         "items": [
@@ -69,6 +71,7 @@ async def test_compute_splits_unmatched_items_go_to_payer():
 
     result = compute_splits(classified, members, uses, "user-1")
 
+    assert result["noSplit"] is True
     splits_by_members = {tuple(s["splitEquallyAmong"]): s for s in result["splits"]}
 
     # Matched item goes to user-1
@@ -79,7 +82,7 @@ async def test_compute_splits_unmatched_items_go_to_payer():
     assert "ZZZ" in upcs
 
 
-async def test_compute_splits_single_member():
+def test_compute_splits_single_member():
     classified = {
         "items": [
             {"upc": "A", "description": "X", "total": 100.0, "category": "item"},
@@ -94,10 +97,11 @@ async def test_compute_splits_single_member():
     assert len(result["splits"]) == 1  # item + fee merge (same member set)
     assert result["splits"][0]["amount"] == 105.0
     assert result["splits"][0]["splitEquallyAmong"] == ["solo"]
+    assert result["noSplit"] is True
 
 
-async def test_compute_splits_unmatched_plus_fees():
-    """Unmatched items go to payer, fees go to everyone."""
+def test_compute_splits_unmatched_plus_fees():
+    """Unmatched items go to payer, fees go to members_with_items (payer only)."""
     classified = {
         "items": [
             {"upc": "A", "description": "Unmatched", "total": 100.0, "category": "item"},
@@ -109,30 +113,25 @@ async def test_compute_splits_unmatched_plus_fees():
 
     result = compute_splits(classified, members, uses, "u1")
 
-    splits_by_members = {tuple(s["splitEquallyAmong"]): s for s in result["splits"]}
-
-    # Unmatched item → payer only
-    assert splits_by_members[("u1",)]["amount"] == 100.0
-
-    # Fee → everyone
-    assert splits_by_members[("u1", "u2")]["amount"] == 5.0
-
-    # Total equals invoice
-    total = sum(s["amount"] for s in result["splits"])
-    assert total == 105.0
+    # Unmatched → payer, fees → payer (only member with items) → single group
+    assert len(result["splits"]) == 1
+    assert result["splits"][0]["splitEquallyAmong"] == ["u1"]
+    assert result["splits"][0]["amount"] == 105.0
+    assert result["noSplit"] is True
 
 
-async def test_compute_splits_empty_items():
+def test_compute_splits_empty_items():
     classified = {"items": []}
     members = {"u1": ["m1"]}
     uses = {"m1": ["A"]}
 
     result = compute_splits(classified, members, uses, "u1")
     assert result["splits"] == []
+    assert result["noSplit"] is True
 
 
-async def test_compute_splits_all_fees():
-    """All items are fees — single split among everyone."""
+def test_compute_splits_all_fees():
+    """All items are fees — fees go to payer only (no non-fee items exist)."""
     classified = {
         "items": [
             {"upc": "-", "description": "Delivery", "total": 5.0, "category": "fee"},
@@ -146,10 +145,11 @@ async def test_compute_splits_all_fees():
 
     assert len(result["splits"]) == 1
     assert result["splits"][0]["amount"] == 8.0
-    assert len(result["splits"][0]["splitEquallyAmong"]) == 3
+    assert result["splits"][0]["splitEquallyAmong"] == ["u1"]
+    assert result["noSplit"] is True
 
 
-async def test_compute_splits_three_way_different_groups():
+def test_compute_splits_three_way_different_groups():
     """Three members, each with unique items + shared items."""
     classified = {
         "items": [
@@ -181,9 +181,10 @@ async def test_compute_splits_three_way_different_groups():
     assert splits_by_members[("alice", "bob")]["amount"] == 30.0
     # D (all 3) + fee (all 3) merge
     assert splits_by_members[("alice", "bob", "carol")]["amount"] == 46.0
+    assert result["noSplit"] is False
 
 
-async def test_compute_splits_rounding():
+def test_compute_splits_rounding():
     """Amounts are rounded to 2 decimal places.
 
     Use totals whose binary float sum is not exactly the mathematical sum
@@ -200,12 +201,13 @@ async def test_compute_splits_rounding():
 
     result = compute_splits(classified, members, uses, "u1")
     assert result["splits"][0]["amount"] == 30.3
+    assert result["noSplit"] is True
 
 
 # --- Total invariant: sum of splits == sum of all classified items ---
 
 
-async def test_total_invariant_all_matched():
+def test_total_invariant_all_matched():
     """When all items match, split total equals invoice total."""
     classified = {
         "items": [
@@ -222,10 +224,11 @@ async def test_total_invariant_all_matched():
     invoice_total = sum(i["total"] for i in classified["items"])
     split_total = sum(s["amount"] for s in result["splits"])
     assert split_total == invoice_total  # 90 == 90
+    assert result["noSplit"] is False
 
 
-async def test_total_invariant_some_unmatched():
-    """Unmatched items go to payer, so total still balances."""
+def test_total_invariant_some_unmatched():
+    """Unmatched items go to payer, fees to members_with_items, total still balances."""
     classified = {
         "items": [
             {"upc": "A", "description": "Matched", "total": 40.0, "category": "item"},
@@ -243,9 +246,14 @@ async def test_total_invariant_some_unmatched():
     split_total = sum(s["amount"] for s in result["splits"])
     assert split_total == invoice_total  # 88 == 88
 
+    # All items go to payer (matched + unmatched + fees) → single group
+    assert len(result["splits"]) == 1
+    assert result["splits"][0]["splitEquallyAmong"] == ["payer"]
+    assert result["noSplit"] is True
 
-async def test_total_invariant_nothing_matched():
-    """When nothing matches, all items go to payer, fees to everyone."""
+
+def test_total_invariant_nothing_matched():
+    """When nothing matches, all items + fees go to payer."""
     classified = {
         "items": [
             {"upc": "A", "description": "Item", "total": 100.0, "category": "item"},
@@ -260,3 +268,80 @@ async def test_total_invariant_nothing_matched():
     invoice_total = sum(i["total"] for i in classified["items"])
     split_total = sum(s["amount"] for s in result["splits"])
     assert split_total == invoice_total  # 105 == 105
+
+    # Everything merges into payer-only group
+    assert len(result["splits"]) == 1
+    assert result["splits"][0]["splitEquallyAmong"] == ["payer"]
+    assert result["noSplit"] is True
+
+
+# --- noSplit detection and fee exclusion ---
+
+
+def test_no_split_false_when_multiple_members_have_items():
+    """noSplit is False when non-payer members have items."""
+    classified = {
+        "items": [
+            {"upc": "A", "description": "Item A", "total": 50.0, "category": "item"},
+            {"upc": "B", "description": "Item B", "total": 30.0, "category": "item"},
+        ],
+    }
+    members = {"payer": ["m1"], "other": ["m2"]}
+    uses = {"m1": ["A"], "m2": ["B"]}
+
+    result = compute_splits(classified, members, uses, "payer")
+
+    assert result["noSplit"] is False
+    splits_by_members = {tuple(s["splitEquallyAmong"]): s for s in result["splits"]}
+    assert ("payer",) in splits_by_members
+    assert ("other",) in splits_by_members
+
+
+def test_fees_only_go_to_members_with_items():
+    """Fees are shared only among members who have at least one non-fee item."""
+    classified = {
+        "items": [
+            {"upc": "A", "description": "Item A", "total": 40.0, "category": "item"},
+            {"upc": "B", "description": "Item B", "total": 60.0, "category": "item"},
+            {"upc": "-", "description": "Delivery", "total": 10.0, "category": "fee"},
+        ],
+    }
+    # alice and bob have items, carol does not
+    members = {"alice": ["m1"], "bob": ["m2"], "carol": []}
+    uses = {"m1": ["A"], "m2": ["B"]}
+
+    result = compute_splits(classified, members, uses, "alice")
+
+    splits_by_members = {tuple(s["splitEquallyAmong"]): s for s in result["splits"]}
+
+    # Fee goes to alice + bob (members with items), not carol
+    fee_group = splits_by_members.get(("alice", "bob"))
+    assert fee_group is not None
+    fee_upcs = [g["upc"] for g in fee_group["groceryItems"]]
+    assert "-" in fee_upcs
+    assert fee_group["amount"] == 10.0
+
+    # carol has no group
+    assert ("carol",) not in splits_by_members
+    assert ("alice", "bob", "carol") not in splits_by_members
+
+
+def test_no_split_true_payer_only_via_correlation():
+    """noSplit is True when correlations assign everything to payer only."""
+    classified = {
+        "items": [
+            {"upc": "A", "description": "Item A", "total": 70.0, "category": "item"},
+            {"upc": "B", "description": "Item B", "total": 30.0, "category": "item"},
+            {"upc": "-", "description": "Fee", "total": 5.0, "category": "fee"},
+        ],
+    }
+    # payer's menu items use all grocery items; other has unrelated menu
+    members = {"payer": ["m1", "m2"], "other": ["m3"]}
+    uses = {"m1": ["A"], "m2": ["B"], "m3": []}
+
+    result = compute_splits(classified, members, uses, "payer")
+
+    assert result["noSplit"] is True
+    assert len(result["splits"]) == 1
+    assert result["splits"][0]["splitEquallyAmong"] == ["payer"]
+    assert result["splits"][0]["amount"] == 105.0

--- a/ui/app/(authenticated)/orders/[id]/expense/page.tsx
+++ b/ui/app/(authenticated)/orders/[id]/expense/page.tsx
@@ -16,6 +16,7 @@ interface GroceryItem {
   upc: string;
   description: string;
   total: number;
+  category?: string;
 }
 
 export default function SplitAnalysisPage() {
@@ -71,10 +72,9 @@ export default function SplitAnalysisPage() {
     const seen = new Set<string>();
     for (const group of splitGroups) {
       for (const gi of group.groceryItems) {
-        if (!seen.has(gi.upc)) {
-          seen.add(gi.upc);
-          items.push({ item: gi, memberIds: [...group.memberIds] });
-        }
+        if (gi.category === "fee" || seen.has(gi.upc)) continue;
+        seen.add(gi.upc);
+        items.push({ item: gi, memberIds: [...group.memberIds] });
       }
     }
     return items.sort((a, b) =>

--- a/ui/lib/api/schema.d.ts
+++ b/ui/lib/api/schema.d.ts
@@ -442,7 +442,7 @@ export interface paths {
         head?: never;
         /**
          * Cancel Order
-         * @description Cancel a draft order. Only the payer can cancel.
+         * @description Cancel a draft or no_split order. Only the payer can cancel.
          */
         patch: operations["cancel_order_api_v1_orders__order_id__cancel_patch"];
         trace?: never;
@@ -457,7 +457,7 @@ export interface paths {
         get?: never;
         /**
          * Edit Splits
-         * @description Edit split assignments for a draft order. Backend recomputes amounts.
+         * @description Edit split assignments for a draft or no_split order. Backend recomputes amounts.
          */
         put: operations["edit_splits_api_v1_orders__order_id__splits_put"];
         post?: never;


### PR DESCRIPTION
## Summary

- Fee items (delivery, handling, platform fees, etc.) are now excluded from the editable item list on the split review page
- Users only see and can reassign actual grocery items
- Fees remain visible in the grouped view mode
- Backend auto-distributes fees to members with items on save (no backend changes needed)

## Test plan

- [ ] Open an order with fees → view mode shows fees in their group
- [ ] Enter edit mode → fee items are NOT in the editable list
- [ ] Save edits → succeeds, fees auto-distributed correctly