### PR TITLE
fix: skip payer-only Splitwise expenses + UI polish for no_split orders

### DIFF
--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -477,8 +477,13 @@ async def approve_order(
 
     # Update split statuses from audit results
     audit_by_desc = {a.request_payload.get("description", ""): a for a in audits}
+    payer_id = str(order.paid_by)
     all_success = True
     for split in order.splits:
+        if split.member_ids == [payer_id]:
+            split.status = "success"
+            continue
+
         item_names = [g["description"] for g in split.grocery_items]
         desc = (
             ", ".join(item_names)

--- a/backend/app/services/splitwise.py
+++ b/backend/app/services/splitwise.py
@@ -269,8 +269,12 @@ async def push_splits_audited(
     """
     _check_enabled()
     audits = []
+    payer_id = split_result["paidBy"]
 
     for split in split_result["splits"]:
+        if split["splitEquallyAmong"] == [payer_id]:
+            continue
+
         sw_ids = []
         for member_id in split["splitEquallyAmong"]:
             sw_id = member_id_to_sw_id.get(member_id)

--- a/backend/tests/test_splitwise.py
+++ b/backend/tests/test_splitwise.py
@@ -513,6 +513,7 @@ async def test_push_splits_audited_missing_sw_id(
     monkeypatch.setattr("app.services.splitwise.settings", _FakeSettings(splitwise_enabled=True))
 
     split_result = {
+        "paidBy": str(user.id),
         "splits": [
             {
                 "amount": 50.0,
@@ -531,6 +532,50 @@ async def test_push_splits_audited_missing_sw_id(
             payer_sw_id=99001,
             token="fake-token",
         )
+
+
+async def test_push_splits_audited_skips_payer_only(
+    session: AsyncSession, order_with_user, monkeypatch
+):
+    """push_splits_audited skips splits where payer is the sole member."""
+    order, user = order_with_user
+    monkeypatch.setattr("app.services.splitwise.settings", _FakeSettings(splitwise_enabled=True))
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"expenses": [{"id": 8001}], "errors": []}
+    mock_resp.raise_for_status = MagicMock()
+    mock_http = MagicMock()
+    mock_http.post.return_value = mock_resp
+    monkeypatch.setattr("app.services.splitwise._http", mock_http)
+
+    split_result = {
+        "paidBy": str(user.id),
+        "splits": [
+            {
+                "amount": 100.0,
+                "groceryItems": [{"description": "Chicken", "total": 100.0}],
+                "splitEquallyAmong": [str(user.id)],
+            },
+            {
+                "amount": 50.0,
+                "groceryItems": [{"description": "Rice", "total": 50.0}],
+                "splitEquallyAmong": [str(user.id), "member-2"],
+            },
+        ],
+    }
+
+    audits = await push_splits_audited(
+        session=session,
+        order_id=order.id,
+        split_result=split_result,
+        member_id_to_sw_id={str(user.id): 99001, "member-2": 99002},
+        payer_sw_id=99001,
+        token="fake-token",
+    )
+
+    assert len(audits) == 1
+    assert audits[0].status == "success"
+    assert mock_http.post.call_count == 1
 
 
 # --- rollback_order_expenses ---

--- a/ui/app/(authenticated)/orders/[id]/expense/page.tsx
+++ b/ui/app/(authenticated)/orders/[id]/expense/page.tsx
@@ -99,24 +99,28 @@ export default function SplitAnalysisPage() {
     [userMap],
   );
 
-  // Sort splits: by group size ascending, then by sorted concatenated member names
+  // Sort splits: payer-only group always last, others by group size then names
   const sortedSplits = useMemo(() => {
     if (splitGroups.length === 0) return [];
+    const payerId = order?.paid_by;
     return [...splitGroups]
       .map((group) => ({
         ...group,
-        groceryItems: [...group.groceryItems].sort((a, b) =>
-          a.description.localeCompare(b.description),
-        ),
+        groceryItems: [...group.groceryItems]
+          .filter((i) => i.category !== "fee")
+          .sort((a, b) => a.description.localeCompare(b.description)),
+        isPayerOnly: group.memberIds.length === 1 && group.memberIds[0] === payerId,
       }))
+      .filter((group) => group.groceryItems.length > 0)
       .sort((a, b) => {
+        if (a.isPayerOnly !== b.isPayerOnly) return a.isPayerOnly ? 1 : -1;
         const sizeDiff = a.memberIds.length - b.memberIds.length;
         if (sizeDiff !== 0) return sizeDiff;
         const aNamesKey = sortedNames(a.memberIds).join(", ");
         const bNamesKey = sortedNames(b.memberIds).join(", ");
         return aNamesKey.localeCompare(bNamesKey);
       });
-  }, [splitGroups, userMap, sortedNames]);
+  }, [splitGroups, userMap, sortedNames, order]);
 
   const isNoSplit = order?.status === "no_split";
   const isTerminal = order?.status === "completed" || order?.status === "cancelled";
@@ -234,7 +238,7 @@ export default function SplitAnalysisPage() {
         {(mode === "view" || isTerminal) && sortedSplits.length > 0 && (
           <div>
             {sortedSplits.map((group, gi) => (
-              <div key={gi} className="border-b border-black last:border-b-0">
+              <div key={gi} className={`border-b border-black last:border-b-0 ${group.isPayerOnly ? "opacity-40" : ""}`}>
                 <div className="p-3">
                   <span className="text-2xl font-bold tracking-label uppercase leading-6">
                     {sortedNames(group.memberIds).join(", ")}

--- a/ui/app/(authenticated)/orders/[id]/expense/page.tsx
+++ b/ui/app/(authenticated)/orders/[id]/expense/page.tsx
@@ -118,6 +118,7 @@ export default function SplitAnalysisPage() {
       });
   }, [splitGroups, userMap, sortedNames]);
 
+  const isNoSplit = order?.status === "no_split";
   const isTerminal = order?.status === "completed" || order?.status === "cancelled";
   const isCompleted = order?.status === "completed";
   const isCancelled = order?.status === "cancelled";
@@ -127,7 +128,7 @@ export default function SplitAnalysisPage() {
       setMode("view");
       return;
     }
-    if (isTerminal) {
+    if (isTerminal || isNoSplit) {
       router.replace("/meal-plan");
       return;
     }
@@ -310,13 +311,22 @@ export default function SplitAnalysisPage() {
         </button>
       )}
 
-      {!isTerminal && mode === "view" && (
+      {!isTerminal && !isNoSplit && mode === "view" && (
         <button
           onClick={handleApprove}
           disabled={submitting}
           className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:bg-neutral-400"
         >
           {submitting ? <div className="size-6 animate-spin rounded-full border-[3px] border-white border-t-transparent" /> : "Split"}
+        </button>
+      )}
+
+      {isNoSplit && mode === "view" && (
+        <button
+          onClick={() => router.replace("/meal-plan")}
+          className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-neutral-400 text-2xl font-bold tracking-label uppercase leading-6 text-white"
+        >
+          No settlement
         </button>
       )}
 


### PR DESCRIPTION
## Summary

- **Backend**: `push_splits_audited` now skips splits where the payer is the sole member — no pointless self-expenses sent to Splitwise. The approve endpoint marks these as "success" locally so the order still transitions to `completed`.
- **UI**: `no_split` orders show a disabled "No settlement" button instead of "Split". Payer-only group is sorted last and grayed out (40% opacity). Fee items (delivery, handling) are hidden from both view and edit modes — only shown on the result page.

## Test plan

- [ ] Backend: `uv run pytest --ignore=tests/test_integration.py -v` — all pass including new `test_push_splits_audited_skips_payer_only`
- [ ] Create an order where payer owns some items exclusively + shares others → approve → verify only shared splits hit Splitwise
- [ ] Open a `no_split` order → button says "No settlement", payer group is grayed at bottom, no fees visible
- [ ] Edit a `no_split` order, assign items to others → status transitions to `draft`, "Split" button appears