### PR TITLE
perf(backend): parallelize I/O with asyncio.gather and semaphores

### DIFF
--- a/backend/app/ai/client.py
+++ b/backend/app/ai/client.py
@@ -10,6 +10,7 @@ LLM providers. The model and provider are configured via Dynaconf settings:
   AI_API_KEY = ""              # only needed for cloud providers
 """
 
+import asyncio
 import json
 
 import litellm
@@ -18,6 +19,16 @@ import structlog
 from opentelemetry import trace
 
 from app.config import settings
+
+_llm_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_llm_semaphore() -> asyncio.Semaphore:
+    global _llm_semaphore
+    if _llm_semaphore is None:
+        _llm_semaphore = asyncio.Semaphore(settings.get("AI_CONCURRENCY", 5))
+    return _llm_semaphore
+
 
 logger = structlog.get_logger()
 
@@ -63,22 +74,23 @@ async def generate(
     )
 
     try:
-        response = await litellm.acompletion(
-            model=model,
-            messages=[
-                {"role": "system", "content": system},
-                {"role": "user", "content": prompt},
-            ],
-            response_format={
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "response",
-                    "schema": schema,
+        async with _get_llm_semaphore():
+            response = await litellm.acompletion(
+                model=model,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": prompt},
+                ],
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "response",
+                        "schema": schema,
+                    },
                 },
-            },
-            api_base=settings.AI_BASE_URL or None,
-            api_key=settings.AI_API_KEY or None,
-        )
+                api_base=settings.AI_BASE_URL or None,
+                api_key=settings.AI_API_KEY or None,
+            )
     except Exception as exc:
         logger.info(
             "llm_error",

--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -54,37 +54,41 @@ async def _snapshot_meal_plans(
     participant_ids: list[uuid.UUID],
 ) -> tuple[dict[str, list[str]], list[dict]]:
     """Snapshot participants' meal plans and collect all menu items."""
+    # Batch query 1: all meal plans at once
+    result = await session.execute(
+        select(MealPlan)
+        .where(MealPlan.user_id.in_(participant_ids))
+        .options(selectinload(MealPlan.items))
+    )
+    plans_by_user = {plan.user_id: plan for plan in result.scalars().all()}
+
     members: dict[str, list[str]] = {}
     seen_menu_item_ids: set[uuid.UUID] = set()
-    all_menu_items: list[dict] = []
 
     for user_id in participant_ids:
-        result = await session.execute(
-            select(MealPlan)
-            .where(MealPlan.user_id == user_id)
-            .options(selectinload(MealPlan.items))
-        )
-        plan = result.scalar_one_or_none()
-
+        plan = plans_by_user.get(user_id)
         if plan is None:
             members[str(user_id)] = []
             continue
-
         menu_item_ids = [str(item.menu_item_id) for item in plan.items]
         members[str(user_id)] = menu_item_ids
-
         for item in plan.items:
-            if item.menu_item_id not in seen_menu_item_ids:
-                seen_menu_item_ids.add(item.menu_item_id)
-                mi = await session.get(MenuItem, item.menu_item_id)
-                if mi:
-                    all_menu_items.append(
-                        {
-                            "id": str(mi.id),
-                            "name": mi.name,
-                            "body": mi.body,
-                        }
-                    )
+            seen_menu_item_ids.add(item.menu_item_id)
+
+    # Batch query 2: all referenced menu items at once
+    all_menu_items: list[dict] = []
+    if seen_menu_item_ids:
+        mi_result = await session.execute(
+            select(MenuItem).where(MenuItem.id.in_(seen_menu_item_ids))
+        )
+        for mi in mi_result.scalars().all():
+            all_menu_items.append(
+                {
+                    "id": str(mi.id),
+                    "name": mi.name,
+                    "body": mi.body,
+                }
+            )
 
     return members, all_menu_items
 
@@ -429,13 +433,16 @@ async def approve_order(
             status_code=400, detail=f"Cannot approve order with status '{order.status}'"
         )
 
-    # Build member_id_to_sw_id mapping from DB
+    # Build member_id_to_sw_id mapping from DB (single bulk query)
     participant_user_ids = [p.user_id for p in order.participants]
     member_id_to_sw_id: dict[str, int] = {}
     payer_sw_id: int | None = None
 
+    users_result = await session.execute(select(User).where(User.id.in_(participant_user_ids)))
+    users_by_id = {u.id: u for u in users_result.scalars().all()}
+
     for uid in participant_user_ids:
-        user = await session.get(User, uid)
+        user = users_by_id.get(uid)
         if not user or user.splitwise_user_id is None:
             raise HTTPException(
                 status_code=400,

--- a/backend/app/services/classify.py
+++ b/backend/app/services/classify.py
@@ -5,6 +5,7 @@ Classifies each extracted grocery item as "item" (product) or "fee"
 (order-level charge) using the configured LLM via LiteLLM.
 """
 
+import asyncio
 import json
 from collections.abc import Callable
 
@@ -60,9 +61,10 @@ async def classify(
 
     logger.info("classify_start", total_items=total_items)
 
+    categories = await asyncio.gather(*[_classify_row(row) for row in all_rows])
+
     classified_rows = []
-    for i, row in enumerate(all_rows, 1):
-        category = await _classify_row(row)
+    for i, (row, category) in enumerate(zip(all_rows, categories, strict=True), 1):
         classified_rows.append({**row, "category": category})
 
         logger.info(

--- a/backend/app/services/correlate.py
+++ b/backend/app/services/correlate.py
@@ -6,6 +6,8 @@ alongside the full list of GroceryItems to the LLM, which returns the
 matched UPCs. This builds the bipartite adjacency used by the split service.
 """
 
+import asyncio
+
 import logfire
 import structlog
 
@@ -87,12 +89,18 @@ async def correlate(
     uses: dict[str, list[str]] = {}
     total_matches = 0
 
-    for item in menu_items:
-        matched = await _correlate_menu_item(
-            menu_item_name=item["name"],
-            menu_item_body=item["body"],
-            grocery_list_text=grocery_list_text,
-        )
+    matched_results = await asyncio.gather(
+        *[
+            _correlate_menu_item(
+                menu_item_name=item["name"],
+                menu_item_body=item["body"],
+                grocery_list_text=grocery_list_text,
+            )
+            for item in menu_items
+        ]
+    )
+
+    for item, matched in zip(menu_items, matched_results, strict=True):
         valid_matched = [upc for upc in matched if upc in valid_upcs]
         uses[str(item["id"])] = valid_matched
         total_matches += len(valid_matched)

--- a/backend/app/services/splitwise.py
+++ b/backend/app/services/splitwise.py
@@ -9,6 +9,7 @@ Every API call is persisted in the splitwise_audit_log table:
 Feature toggle: SPLITWISE_ENABLED must be true or all calls are refused.
 """
 
+import asyncio
 import hashlib
 import json
 import uuid
@@ -19,9 +20,19 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
+from app.database import async_session as _async_session
 from app.models.splitwise_audit import SplitwiseAuditLog
 
 _http = httpx.Client(timeout=30)
+
+_sw_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_sw_semaphore() -> asyncio.Semaphore:
+    global _sw_semaphore
+    if _sw_semaphore is None:
+        _sw_semaphore = asyncio.Semaphore(settings.get("SPLITWISE_CONCURRENCY", 3))
+    return _sw_semaphore
 
 
 def _base_url() -> str:
@@ -170,7 +181,9 @@ async def create_expense_audited(
 
     # Step 2: Call Splitwise API
     try:
-        resp = _http.post(f"{_base_url()}/create_expense", headers=_headers(token), json=payload)
+        resp = await asyncio.to_thread(
+            _http.post, f"{_base_url()}/create_expense", headers=_headers(token), json=payload
+        )
         resp.raise_for_status()
         data = resp.json()
 
@@ -217,7 +230,8 @@ async def delete_expense_audited(
     await session.refresh(audit)
 
     try:
-        resp = _http.post(
+        resp = await asyncio.to_thread(
+            _http.post,
             f"{_base_url()}/delete_expense/{splitwise_expense_id}",
             headers=_headers(token),
         )
@@ -257,7 +271,7 @@ async def push_splits_audited(
     """Push all split groups to Splitwise with per-expense auditing.
 
     Args:
-        session: DB session.
+        session: DB session (used for idempotency checks).
         order_id: Our order UUID (for audit trail).
         split_result: Output of compute_splits().
         member_id_to_sw_id: Map of our member ID → Splitwise user ID.
@@ -268,9 +282,10 @@ async def push_splits_audited(
         List of audit log rows (one per split).
     """
     _check_enabled()
-    audits = []
     payer_id = split_result["paidBy"]
 
+    # Pre-validate and build task inputs before firing parallel requests
+    task_inputs: list[tuple[str, float, list[int], str]] = []
     for split in split_result["splits"]:
         if split["splitEquallyAmong"] == [payer_id]:
             continue
@@ -292,21 +307,27 @@ async def push_splits_audited(
         details_lines = [f"- {g['description']}: ₹{g['total']:.2f}" for g in split["groceryItems"]]
         details = "\n".join(details_lines)
 
-        audit = await create_expense_audited(
-            session=session,
-            description=desc,
-            cost=split["amount"],
-            payer_sw_id=payer_sw_id,
-            member_sw_ids=sw_ids,
-            order_id=order_id,
-            group_id=group_id,
-            details=details,
-            token=token,
-        )
-        audits.append(audit)
+        task_inputs.append((desc, split["amount"], sw_ids, details))
 
+    async def _create_one(desc: str, cost: float, sw_ids: list[int], details: str):
+        async with _get_sw_semaphore(), _async_session() as task_session:
+            return await create_expense_audited(
+                session=task_session,
+                description=desc,
+                cost=cost,
+                payer_sw_id=payer_sw_id,
+                member_sw_ids=sw_ids,
+                order_id=order_id,
+                group_id=group_id,
+                details=details,
+                token=token,
+            )
+
+    audits = list(await asyncio.gather(*[_create_one(*args) for args in task_inputs]))
+
+    for audit, (desc, cost, _, _) in zip(audits, task_inputs, strict=True):
         status_icon = "✓" if audit.status == "success" else "✗"
-        print(f"  {status_icon} ₹{split['amount']:.2f} — {desc} [{audit.status}]")
+        print(f"  {status_icon} ₹{cost:.2f} — {desc} [{audit.status}]")
 
     return audits
 
@@ -332,15 +353,18 @@ async def rollback_order_expenses(
     )
     successful = result.scalars().all()
 
-    delete_audits = []
-    for audit_row in successful:
-        delete_audit = await delete_expense_audited(
-            session=session,
-            splitwise_expense_id=audit_row.splitwise_expense_id,
-            order_id=order_id,
-            token=token,
-        )
-        delete_audits.append(delete_audit)
+    async def _delete_one(expense_id: int):
+        async with _get_sw_semaphore(), _async_session() as task_session:
+            return await delete_expense_audited(
+                session=task_session,
+                splitwise_expense_id=expense_id,
+                order_id=order_id,
+                token=token,
+            )
+
+    delete_audits = list(
+        await asyncio.gather(*[_delete_one(row.splitwise_expense_id) for row in successful])
+    )
 
     return delete_audits
 

--- a/backend/settings.toml
+++ b/backend/settings.toml
@@ -8,6 +8,7 @@ AI_PROVIDER = "ollama"
 AI_MODEL = "qwen2.5:3b"
 AI_BASE_URL = "http://localhost:11434"
 AI_API_KEY = ""
+AI_CONCURRENCY = 5
 
 # Tracing (Pydantic Logfire → OTel)
 TRACING_ENABLED = true
@@ -34,6 +35,7 @@ SPLITWISE_OAUTH_BASE_URL = "http://localhost:8001"
 SPLITWISE_API_KEY = ""
 SPLITWISE_CONSUMER_KEY = ""
 SPLITWISE_CONSUMER_SECRET = ""
+SPLITWISE_CONCURRENCY = 3
 
 # Frontend URL (for OAuth callback redirects)
 FRONTEND_URL = "http://localhost:3000"

--- a/backend/tests/test_ai_client.py
+++ b/backend/tests/test_ai_client.py
@@ -25,6 +25,7 @@ async def test_generate_calls_litellm_and_parses_json(monkeypatch):
         "app.ai.client.settings",
         _FakeAISettings("ollama", "test-model", "http://localhost:11434", ""),
     )
+    monkeypatch.setattr("app.ai.client._llm_semaphore", None)
 
     mock_response = MagicMock()
     mock_response.choices = [MagicMock()]
@@ -56,3 +57,6 @@ class _FakeAISettings:
         self.AI_MODEL = model
         self.AI_BASE_URL = base_url
         self.AI_API_KEY = api_key
+
+    def get(self, key, default=None):
+        return getattr(self, key, default)

--- a/backend/tests/test_pipeline_integration.py
+++ b/backend/tests/test_pipeline_integration.py
@@ -23,6 +23,7 @@ from app.models.order_source import OrderSource, OrderSourceType
 from app.models.split import Split
 from app.models.splitwise_audit import SplitwiseAuditLog
 from app.models.user import User
+from tests.conftest import test_async_session
 
 # --- Fixtures ---
 
@@ -426,6 +427,8 @@ async def test_approve_order_happy_path(
 
     with (
         patch("app.services.splitwise._http", mock_http),
+        patch("app.services.splitwise._async_session", test_async_session),
+        patch("app.services.splitwise._sw_semaphore", None),
         patch(
             "app.services.vault.get_secret",
             new_callable=AsyncMock,
@@ -503,6 +506,8 @@ async def test_approve_order_partial_failure(
 
     with (
         patch("app.services.splitwise._http", mock_http),
+        patch("app.services.splitwise._async_session", test_async_session),
+        patch("app.services.splitwise._sw_semaphore", None),
         patch(
             "app.services.vault.get_secret",
             new_callable=AsyncMock,

--- a/backend/tests/test_splitwise.py
+++ b/backend/tests/test_splitwise.py
@@ -23,6 +23,7 @@ from app.services.splitwise import (
     push_splits_audited,
     rollback_order_expenses,
 )
+from tests.conftest import test_async_session
 
 # --- Feature toggle ---
 
@@ -465,6 +466,8 @@ async def test_push_splits_audited_success(session: AsyncSession, order_with_use
     """push_splits_audited creates one audit per split group."""
     order, user = order_with_user
     monkeypatch.setattr("app.services.splitwise.settings", _FakeSettings(splitwise_enabled=True))
+    monkeypatch.setattr("app.services.splitwise._async_session", test_async_session)
+    monkeypatch.setattr("app.services.splitwise._sw_semaphore", None)
 
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"expenses": [{"id": 7001}], "errors": []}
@@ -540,6 +543,8 @@ async def test_push_splits_audited_skips_payer_only(
     """push_splits_audited skips splits where payer is the sole member."""
     order, user = order_with_user
     monkeypatch.setattr("app.services.splitwise.settings", _FakeSettings(splitwise_enabled=True))
+    monkeypatch.setattr("app.services.splitwise._async_session", test_async_session)
+    monkeypatch.setattr("app.services.splitwise._sw_semaphore", None)
 
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"expenses": [{"id": 8001}], "errors": []}
@@ -585,6 +590,8 @@ async def test_rollback_order_expenses(session: AsyncSession, order_with_user, m
     """rollback_order_expenses deletes all successful expenses for an order."""
     order, _ = order_with_user
     monkeypatch.setattr("app.services.splitwise.settings", _FakeSettings(splitwise_enabled=True))
+    monkeypatch.setattr("app.services.splitwise._async_session", test_async_session)
+    monkeypatch.setattr("app.services.splitwise._sw_semaphore", None)
 
     # Create a "success" audit row as if a previous expense was created
     audit = SplitwiseAuditLog(


### PR DESCRIPTION
## Summary

- **LLM calls** (`classify` + `correlate`): `asyncio.gather` with `AI_CONCURRENCY=5` semaphore — all rows/items processed in parallel instead of sequentially
- **Splitwise API**: `asyncio.gather` with `SPLITWISE_CONCURRENCY=3` semaphore, per-task DB sessions, `asyncio.to_thread` for sync httpx calls
- **DB queries**: Batch `WHERE id IN(...)` queries in `_snapshot_meal_plans()` (2 queries instead of N+M) and `approve_order()` (1 query instead of N)

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .` — lint clean
- [x] `uv run pytest --ignore=tests/test_integration.py -v` — 255 passed, 95% coverage
- [ ] Integration test with local Ollama: verify pipeline completes faster
- [ ] Monitor LLM rate-limit errors and Splitwise 429s post-deploy, adjust `AI_CONCURRENCY`/`SPLITWISE_CONCURRENCY` if needed