### PR TITLE
fix(ui): polish split page headings and actions

### DIFF
--- a/ui/app/(authenticated)/orders/[id]/expense/page.tsx
+++ b/ui/app/(authenticated)/orders/[id]/expense/page.tsx
@@ -200,8 +200,9 @@ export default function SplitAnalysisPage() {
       <div className="flex flex-1 flex-col">
         <TopBar showBack onBack={handleBack} />
         <div className="flex items-stretch justify-between border-b border-black">
-          <span className="flex items-center p-3 text-2xl font-bold tracking-label uppercase leading-6">
-            Split review
+          <span className="flex items-center gap-2 p-3 text-2xl font-bold tracking-label uppercase leading-6">
+            <Icon name="arrow_split" size={24} />
+            Split
           </span>
         </div>
         <main className="flex-1" />
@@ -217,10 +218,10 @@ export default function SplitAnalysisPage() {
       {/* Status bar */}
       <div className="flex items-stretch justify-between border-b border-black">
         <span className="flex items-center gap-2 p-3 text-2xl font-bold tracking-label uppercase leading-6">
+          <Icon name="arrow_split" size={24} />
           Split
           {isCompleted && <Icon name="check_circle" size={24} className="text-green-600" />}
           {isCancelled && <Icon name="close" size={24} className="text-red-600" />}
-          {!isTerminal && " review"}
         </span>
         {!isTerminal && mode === "view" && (
           <button
@@ -229,6 +230,20 @@ export default function SplitAnalysisPage() {
             className="flex items-center justify-center p-3 bg-black"
           >
             <Icon name="edit" size={24} className="text-white" />
+          </button>
+        )}
+        {!isTerminal && mode === "edit" && (
+          <button
+            onClick={handleConfirmEdits}
+            disabled={submitting}
+            aria-label="Confirm edits"
+            className="flex items-center justify-center w-12 bg-black disabled:bg-neutral-400"
+          >
+            {submitting ? (
+              <div className="size-5 animate-spin motion-reduce:animate-none rounded-full border-2 border-white border-t-transparent" />
+            ) : (
+              <Icon name="check" size={24} className="text-white" />
+            )}
           </button>
         )}
       </div>
@@ -319,9 +334,9 @@ export default function SplitAnalysisPage() {
         <button
           onClick={handleApprove}
           disabled={submitting}
-          className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:bg-neutral-400"
+          className="sticky bottom-0 flex w-full items-center justify-center gap-2 p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:bg-neutral-400"
         >
-          {submitting ? <div className="size-6 animate-spin rounded-full border-[3px] border-white border-t-transparent" /> : "Split"}
+          {submitting ? <div className="size-6 animate-spin rounded-full border-[3px] border-white border-t-transparent" /> : <><span>Splitwise</span><Icon name="send" size={24} /></>}
         </button>
       )}
 
@@ -331,16 +346,6 @@ export default function SplitAnalysisPage() {
           className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-neutral-400 text-2xl font-bold tracking-label uppercase leading-6 text-white"
         >
           No settlement
-        </button>
-      )}
-
-      {!isTerminal && mode === "edit" && (
-        <button
-          onClick={handleConfirmEdits}
-          disabled={submitting}
-          className="sticky bottom-0 flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:bg-neutral-400"
-        >
-          {submitting ? <div className="size-6 animate-spin rounded-full border-[3px] border-white border-t-transparent" /> : "Confirm"}
         </button>
       )}
 

--- a/ui/app/(authenticated)/orders/new/page.tsx
+++ b/ui/app/(authenticated)/orders/new/page.tsx
@@ -170,7 +170,8 @@ function InvoiceSetupContent() {
       <TopBar showBack onBack={() => router.push("/meal-plan")} />
 
       {/* Expense heading */}
-      <div className="flex items-center p-3 border-b border-black">
+      <div className="flex items-center gap-2 p-3 border-b border-black">
+        <Icon name="currency_rupee" size={24} />
         <span className="text-2xl font-bold tracking-label uppercase leading-6">
           Expense
         </span>
@@ -179,7 +180,7 @@ function InvoiceSetupContent() {
       {/* Participants */}
       <div className="flex items-stretch border-b border-gray-200">
         <div className="flex flex-wrap items-center gap-1 p-3 flex-1 text-base leading-6">
-          <span>With <b>You</b>, and:</span>
+          <span>With <b>You</b>, &:</span>
           <ChipInput
             ref={chipInputRef}
             participants={otherUsers}

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=account_circle,add,arrow_back_ios_new,arrow_drop_down,arrow_drop_up,check,check_circle,chevron_right,close,delete,description,drag_indicator,edit,expand_less,expand_more,fork_spoon,login,logout,more_horiz,open_in_new,receipt_long,search,settings,upload_file&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=account_circle,add,arrow_back_ios_new,arrow_drop_down,arrow_drop_up,arrow_split,check,check_circle,chevron_right,close,currency_rupee,delete,description,drag_indicator,edit,expand_less,expand_more,fork_spoon,login,logout,more_horiz,open_in_new,receipt_long,search,send,settings,upload_file&display=swap"
         />
       </head>
       <body className="min-h-dvh flex flex-col font-mono bg-white text-black">


### PR DESCRIPTION
## Summary
- Add `currency_rupee` icon before "Expense" heading on `/orders/new`
- Change "With You, and:" to "With You, &:"
- Replace "Split review" heading with `arrow_split` icon + "SPLIT"
- Change approve button from "Split" to "Splitwise" with `send` icon
- Move edit confirm button from bottom bar to heading row (check icon with spinner)

## Test plan
- [x] Verified `/orders/new` renders ₹ icon and "&:" text
- [x] Verified `/orders/[id]/expense` view mode shows arrow_split + SPLIT heading, edit button, and "Splitwise send" bottom button
- [x] Verified edit mode shows check icon in heading row (no bottom confirm)
- [x] Verified completed order shows green check_circle status icon
- [x] TypeScript compiles cleanly