### PR TITLE
fix(ui): route new users to /onboarding instead of error page

### DIFF
--- a/ui/app/auth/callback/__tests__/route.test.ts
+++ b/ui/app/auth/callback/__tests__/route.test.ts
@@ -88,6 +88,19 @@ describe("GET /auth/callback", () => {
     expect(getRedirectPath(response)).toBe("/login?error=backend");
   });
 
+  it("redirects to /onboarding when backend returns 404 (new user)", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({
+      data: { session: { access_token: "tok" } },
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ detail: "User not found" }), { status: 404 }),
+    );
+
+    const response = await GET(makeRequest("?code=abc"));
+    expect(response.status).toBe(307);
+    expect(getRedirectPath(response)).toBe("/onboarding");
+  });
+
   it("sets cookie and redirects to / when splitwise_connected", async () => {
     mockExchangeCodeForSession.mockResolvedValue({
       data: { session: { access_token: "tok" } },

--- a/ui/app/auth/callback/route.ts
+++ b/ui/app/auth/callback/route.ts
@@ -47,5 +47,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL("/onboarding", origin));
   }
 
+  if (meResp.status === 404) {
+    return NextResponse.redirect(new URL("/onboarding", origin));
+  }
+
   return NextResponse.redirect(new URL("/login?error=backend", origin));
 }

--- a/ui/lib/supabase/__tests__/proxy.test.ts
+++ b/ui/lib/supabase/__tests__/proxy.test.ts
@@ -152,6 +152,19 @@ describe("updateSession (proxy auth routing)", () => {
       expect(response.cookies.get(RETURN_TO_COOKIE)).toBeUndefined();
     });
 
+    it("does NOT overwrite existing returnTo when redirecting to /onboarding", async () => {
+      mockGetClaims.mockResolvedValue({
+        data: { claims: { sub: "user-123", email: "test@test.com" } },
+      });
+      const response = await updateSession(
+        makeRequest("/some-page", { [RETURN_TO_COOKIE]: "/import?supplier=cartwise/starter" }),
+      );
+      expect(response.status).toBe(307);
+      expect(getRedirectPath(response)).toBe("/onboarding");
+      const cookie = response.cookies.get(RETURN_TO_COOKIE);
+      expect(cookie).toBeUndefined();
+    });
+
     it("preserves query string in returnTo cookie", async () => {
       mockGetClaims.mockResolvedValue({ data: { claims: null } });
       const response = await updateSession(makeRequest("/meal-plan?tab=week&view=grid"));

--- a/ui/lib/supabase/proxy.ts
+++ b/ui/lib/supabase/proxy.ts
@@ -57,8 +57,10 @@ export async function updateSession(request: NextRequest) {
     url.pathname = "/onboarding";
     url.search = "";
     const response = NextResponse.redirect(url);
-    const returnTo = pathname + (request.nextUrl.search || "");
-    response.cookies.set(RETURN_TO_COOKIE, returnTo, RETURN_TO_COOKIE_OPTIONS);
+    if (!request.cookies.get(RETURN_TO_COOKIE)?.value) {
+      const returnTo = pathname + (request.nextUrl.search || "");
+      response.cookies.set(RETURN_TO_COOKIE, returnTo, RETURN_TO_COOKIE_OPTIONS);
+    }
     return response;
   }
 


### PR DESCRIPTION
## Summary

- Fix auth callback treating 404 from `/auth/me` as a backend error — it now correctly routes new users to `/onboarding`
- Fix proxy unconditionally overwriting the `returnTo` cookie — it now preserves existing values

## Root Cause

PR #89 restructured the auth callback and changed the fallback from `/onboarding` to `/login?error=backend`. This meant new users (who get 404 from `/auth/me` because they haven't onboarded yet) were sent to the error page instead of onboarding. The resulting redirect chain (`/login?error=backend` → `/` → `/onboarding`) overwrote the `returnTo` cookie with garbage, so the import deep-link was lost.

Full investigation: `import-flow-debug.md` at repo root.

## Test plan

- [x] New test: auth callback returns 404 → redirects to `/onboarding`
- [x] New test: proxy doesn't overwrite existing `returnTo` cookie
- [x] All 63 frontend tests pass
- [x] `next build` succeeds
- [ ] Manual: delete user, incognito, navigate import URL → complete auth + onboarding → lands on `/import?supplier=...`