### PR TITLE
feat(observability): expose request/trace IDs in import error UI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["X-Request-ID", "X-Trace-ID"],
 )
 
 # Dev-only: slow down API responses to test loading states

--- a/backend/app/middleware/request_logging.py
+++ b/backend/app/middleware/request_logging.py
@@ -90,4 +90,9 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         )
 
         response.headers["X-Request-ID"] = request_id
+
+        trace_id = trace.get_current_span().get_span_context().trace_id
+        if trace_id:
+            response.headers["X-Trace-ID"] = format(trace_id, "032x")
+
         return response

--- a/ui/app/(authenticated)/import/page.tsx
+++ b/ui/app/(authenticated)/import/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRequiredAuth } from "@/lib/auth";
+import { $api } from "@/lib/api/hooks";
 import apiClient from "@/lib/api/client";
 import { TopBar } from "@/components/top-bar";
 import { MealPlanItem } from "@/components/meal-plan-item";
@@ -18,18 +19,27 @@ export default function ImportPage() {
   );
 }
 
-type PreviewData = {
-  name: string;
-  items: { name: string }[];
-  total: number;
-};
-
 type ImportState =
-  | { status: "loading" }
-  | { status: "preview"; data: PreviewData }
+  | { status: "idle" }
   | { status: "importing" }
   | { status: "done"; persist: number; skip: number }
-  | { status: "error"; phase: "preview" | "import" };
+  | { status: "error"; phase: "preview" | "import"; requestId?: string; traceId?: string };
+
+function buildIssueUrl(phase: string, requestId?: string, traceId?: string) {
+  const description = `Import ${phase} failed.`;
+  const reproduce = [
+    `1. Open the import page`,
+    `2. Error occurred during: ${phase}`,
+    requestId && `- Request ID: \`${requestId}\``,
+    traceId && `- Trace ID: \`${traceId}\``,
+  ].filter(Boolean).join("\n");
+  const params = new URLSearchParams({
+    template: "bug_report.yml",
+    description,
+    reproduce,
+  });
+  return `https://github.com/dostarora97/cartwise/issues/new?${params}`;
+}
 
 function ImportContent() {
   useRequiredAuth();
@@ -38,38 +48,32 @@ function ImportContent() {
   const queryClient = useQueryClient();
   const token = searchParams.get("supplier");
 
-  const [state, setState] = useState<ImportState>({ status: "loading" });
+  const [state, setState] = useState<ImportState>({ status: "idle" });
 
-  const loadPreview = useCallback(async () => {
-    if (!token) return;
-    setState({ status: "loading" });
-    try {
-      const { data, error } = await apiClient.GET("/api/v1/imports/preview", {
-        params: { query: { supplier: token } },
-      });
-      if (error) throw error;
-      setState({ status: "preview", data: data as PreviewData });
-    } catch {
-      setState({ status: "error", phase: "preview" });
-    }
-  }, [token]);
+  const { data: preview, error: previewError, isLoading } = $api.useQuery(
+    "get",
+    "/api/v1/imports/preview",
+    { params: { query: { supplier: token! } } },
+    { enabled: !!token },
+  );
 
   useEffect(() => {
     if (!token) {
       router.replace("/meal-plan");
-      return;
     }
-    loadPreview();
-  }, [token, router, loadPreview]);
+  }, [token, router]);
 
   async function handleImport() {
     if (!token) return;
     setState({ status: "importing" });
     try {
-      const { data, error } = await apiClient.POST("/api/v1/imports/", {
+      const { data, error, response } = await apiClient.POST("/api/v1/imports/", {
         body: { supplier: token },
       });
-      if (error) throw error;
+      if (error) {
+        setState({ status: "error", phase: "import", requestId: response.headers.get("X-Request-ID") ?? undefined, traceId: response.headers.get("X-Trace-ID") ?? undefined });
+        return;
+      }
       await queryClient.invalidateQueries({
         queryKey: ["get", "/api/v1/meal-plans"],
       });
@@ -86,6 +90,8 @@ function ImportContent() {
     }
   }
 
+  const showCenter = isLoading || state.status === "importing" || state.status === "error" || state.status === "done" || previewError;
+
   return (
     <div className="flex flex-1 flex-col">
       <TopBar showBack onBack={() => router.push("/meal-plan")} />
@@ -97,12 +103,12 @@ function ImportContent() {
         </span>
       </div>
 
-      <main className={`flex flex-1 flex-col ${state.status === "loading" || state.status === "importing" || state.status === "error" || state.status === "done" ? "items-center justify-center" : ""}`}>
-        {state.status === "loading" && <Spinner />}
+      <main className={`flex flex-1 flex-col ${showCenter ? "items-center justify-center" : ""}`}>
+        {isLoading && <Spinner />}
 
-        {state.status === "preview" && (
+        {preview && state.status === "idle" && (
           <ul>
-            {state.data.items.map((item, i) => (
+            {preview.items.map((item, i) => (
               <MealPlanItem key={i} name={item.name} mode="view" />
             ))}
           </ul>
@@ -121,28 +127,44 @@ function ImportContent() {
           </div>
         )}
 
-        {state.status === "error" && (
+        {(state.status === "error" || (previewError && state.status === "idle")) && (
           <div className="flex flex-col items-center gap-4">
             <p className="text-xs text-red-600 tracking-wider">
-              {state.phase === "preview"
-                ? "Could not load import preview"
-                : "Import failed"}
+              {state.status === "error" && state.phase === "import"
+                ? "Import failed"
+                : "Could not load import preview"}
             </p>
+            {state.status === "error" && (state.requestId || state.traceId) && (
+              <ul className="text-xs text-gray-400 font-mono">
+                {state.requestId && <li>req: {state.requestId}</li>}
+                {state.traceId && <li>trace: {state.traceId}</li>}
+              </ul>
+            )}
             <button
-              onClick={state.phase === "preview" ? loadPreview : handleImport}
+              onClick={state.status === "error" && state.phase === "import" ? handleImport : () => queryClient.invalidateQueries({ queryKey: ["get", "/api/v1/imports/preview"] })}
               className="border-2 border-black px-6 py-3 text-base font-bold tracking-label uppercase"
             >
               Retry
             </button>
+            {state.status === "error" && (
+              <a
+                href={buildIssueUrl(state.phase, state.requestId, state.traceId)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-gray-400 underline"
+              >
+                Report issue
+              </a>
+            )}
           </div>
         )}
       </main>
 
       <div className="sticky bottom-0">
-        {state.status === "preview" && (
+        {preview && state.status === "idle" && (
           <button
             onClick={handleImport}
-            disabled={state.data.total === 0}
+            disabled={preview.total === 0}
             className="flex w-full items-center justify-center p-3 border-t border-black bg-black text-2xl font-bold tracking-label uppercase leading-6 text-white disabled:bg-neutral-400"
           >
             Import

--- a/ui/app/(authenticated)/import/page.tsx
+++ b/ui/app/(authenticated)/import/page.tsx
@@ -4,10 +4,12 @@ import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRequiredAuth } from "@/lib/auth";
+import { extractRequestIds } from "@/lib/errors";
 import { $api } from "@/lib/api/hooks";
 import apiClient from "@/lib/api/client";
 import { TopBar } from "@/components/top-bar";
 import { MealPlanItem } from "@/components/meal-plan-item";
+import { ErrorBody } from "@/components/error-body";
 import { Icon } from "@/components/icon";
 import { Spinner } from "@/components/spinner";
 
@@ -23,23 +25,7 @@ type ImportState =
   | { status: "idle" }
   | { status: "importing" }
   | { status: "done"; persist: number; skip: number }
-  | { status: "error"; phase: "preview" | "import"; requestId?: string; traceId?: string };
-
-function buildIssueUrl(phase: string, requestId?: string, traceId?: string) {
-  const description = `Import ${phase} failed.`;
-  const reproduce = [
-    `1. Open the import page`,
-    `2. Error occurred during: ${phase}`,
-    requestId && `- Request ID: \`${requestId}\``,
-    traceId && `- Trace ID: \`${traceId}\``,
-  ].filter(Boolean).join("\n");
-  const params = new URLSearchParams({
-    template: "bug_report.yml",
-    description,
-    reproduce,
-  });
-  return `https://github.com/dostarora97/cartwise/issues/new?${params}`;
-}
+  | { status: "error"; message: string; requestId?: string; traceId?: string };
 
 function ImportContent() {
   useRequiredAuth();
@@ -71,7 +57,8 @@ function ImportContent() {
         body: { supplier: token },
       });
       if (error) {
-        setState({ status: "error", phase: "import", requestId: response.headers.get("X-Request-ID") ?? undefined, traceId: response.headers.get("X-Trace-ID") ?? undefined });
+        const ids = extractRequestIds(response);
+        setState({ status: "error", message: "Import failed", ...ids });
         return;
       }
       await queryClient.invalidateQueries({
@@ -86,7 +73,7 @@ function ImportContent() {
         skip: data!.intents_applied.skip ?? 0,
       });
     } catch {
-      setState({ status: "error", phase: "import" });
+      setState({ status: "error", message: "Import failed" });
     }
   }
 
@@ -128,35 +115,12 @@ function ImportContent() {
         )}
 
         {(state.status === "error" || (previewError && state.status === "idle")) && (
-          <div className="flex flex-col items-center gap-4">
-            <p className="text-xs text-red-600 tracking-wider">
-              {state.status === "error" && state.phase === "import"
-                ? "Import failed"
-                : "Could not load import preview"}
-            </p>
-            {state.status === "error" && (state.requestId || state.traceId) && (
-              <ul className="text-xs text-gray-400 font-mono">
-                {state.requestId && <li>req: {state.requestId}</li>}
-                {state.traceId && <li>trace: {state.traceId}</li>}
-              </ul>
-            )}
-            <button
-              onClick={state.status === "error" && state.phase === "import" ? handleImport : () => queryClient.invalidateQueries({ queryKey: ["get", "/api/v1/imports/preview"] })}
-              className="border-2 border-black px-6 py-3 text-base font-bold tracking-label uppercase"
-            >
-              Retry
-            </button>
-            {state.status === "error" && (
-              <a
-                href={buildIssueUrl(state.phase, state.requestId, state.traceId)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-gray-400 underline"
-              >
-                Report issue
-              </a>
-            )}
-          </div>
+          <ErrorBody
+            message={state.status === "error" ? state.message : "Could not load import preview"}
+            requestId={state.status === "error" ? state.requestId : undefined}
+            traceId={state.status === "error" ? state.traceId : undefined}
+            onRetry={state.status === "error" ? handleImport : () => queryClient.invalidateQueries({ queryKey: ["get", "/api/v1/imports/preview"] })}
+          />
         )}
       </main>
 

--- a/ui/components/error-body.tsx
+++ b/ui/components/error-body.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { buildIssueUrl } from "@/lib/errors";
+
+interface ErrorBodyProps {
+  message: string;
+  requestId?: string;
+  traceId?: string;
+  onRetry?: () => void;
+}
+
+export function ErrorBody({ message, requestId, traceId, onRetry }: ErrorBodyProps) {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <p className="text-xs text-red-600 tracking-wider">{message}</p>
+      {(requestId || traceId) && (
+        <ul className="text-xs text-gray-400 font-mono">
+          {requestId && <li>req: {requestId}</li>}
+          {traceId && <li>trace: {traceId}</li>}
+        </ul>
+      )}
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="border-2 border-black px-6 py-3 text-base font-bold tracking-label uppercase"
+        >
+          Retry
+        </button>
+      )}
+      <a
+        href={buildIssueUrl({ message, requestId, traceId })}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-gray-400 underline"
+      >
+        Report issue
+      </a>
+    </div>
+  );
+}

--- a/ui/components/error-body.tsx
+++ b/ui/components/error-body.tsx
@@ -1,15 +1,27 @@
 "use client";
 
-import { buildIssueUrl } from "@/lib/errors";
+import { usePathname } from "next/navigation";
+import { type ErrorContext, buildIssueUrl } from "@/lib/errors";
 
 interface ErrorBodyProps {
   message: string;
   requestId?: string;
   traceId?: string;
+  stack?: string;
   onRetry?: () => void;
 }
 
-export function ErrorBody({ message, requestId, traceId, onRetry }: ErrorBodyProps) {
+export function ErrorBody({ message, requestId, traceId, stack, onRetry }: ErrorBodyProps) {
+  const pathname = usePathname();
+
+  const ctx: ErrorContext = {
+    message,
+    requestId,
+    traceId,
+    stack,
+    pageUrl: typeof window !== "undefined" ? window.location.href : pathname,
+  };
+
   return (
     <div className="flex flex-col items-center gap-4">
       <p className="text-xs text-red-600 tracking-wider">{message}</p>
@@ -28,7 +40,7 @@ export function ErrorBody({ message, requestId, traceId, onRetry }: ErrorBodyPro
         </button>
       )}
       <a
-        href={buildIssueUrl({ message, requestId, traceId })}
+        href={buildIssueUrl(ctx)}
         target="_blank"
         rel="noopener noreferrer"
         className="text-xs text-gray-400 underline"

--- a/ui/lib/errors.ts
+++ b/ui/lib/errors.ts
@@ -1,0 +1,29 @@
+export function extractRequestIds(response: Response): {
+  requestId?: string;
+  traceId?: string;
+} {
+  return {
+    requestId: response.headers.get("X-Request-ID") ?? undefined,
+    traceId: response.headers.get("X-Trace-ID") ?? undefined,
+  };
+}
+
+export function buildIssueUrl(opts: {
+  message: string;
+  requestId?: string;
+  traceId?: string;
+}) {
+  const reproduce = [
+    `Error: ${opts.message}`,
+    opts.requestId && `- Request ID: \`${opts.requestId}\``,
+    opts.traceId && `- Trace ID: \`${opts.traceId}\``,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  const params = new URLSearchParams({
+    template: "bug_report.yml",
+    description: opts.message,
+    reproduce,
+  });
+  return `https://github.com/dostarora97/cartwise/issues/new?${params}`;
+}

--- a/ui/lib/errors.ts
+++ b/ui/lib/errors.ts
@@ -1,3 +1,11 @@
+export interface ErrorContext {
+  message: string;
+  requestId?: string;
+  traceId?: string;
+  stack?: string;
+  pageUrl?: string;
+}
+
 export function extractRequestIds(response: Response): {
   requestId?: string;
   traceId?: string;
@@ -8,21 +16,19 @@ export function extractRequestIds(response: Response): {
   };
 }
 
-export function buildIssueUrl(opts: {
-  message: string;
-  requestId?: string;
-  traceId?: string;
-}) {
+export function buildIssueUrl(ctx: ErrorContext): string {
   const reproduce = [
-    `Error: ${opts.message}`,
-    opts.requestId && `- Request ID: \`${opts.requestId}\``,
-    opts.traceId && `- Trace ID: \`${opts.traceId}\``,
+    `**Error:** ${ctx.message}`,
+    ctx.pageUrl && `**Page:** ${ctx.pageUrl}`,
+    ctx.requestId && `**Request ID:** \`${ctx.requestId}\``,
+    ctx.traceId && `**Trace ID:** \`${ctx.traceId}\``,
+    ctx.stack && `**Stack:**\n\`\`\`\n${ctx.stack}\n\`\`\``,
   ]
     .filter(Boolean)
     .join("\n");
   const params = new URLSearchParams({
     template: "bug_report.yml",
-    description: opts.message,
+    description: ctx.message,
     reproduce,
   });
   return `https://github.com/dostarora97/cartwise/issues/new?${params}`;


### PR DESCRIPTION
## Summary
- Adds `X-Trace-ID` response header (OpenTelemetry trace context) to every response
- Exposes `X-Request-ID` and `X-Trace-ID` via CORS `expose_headers` so the browser can read them
- Shows request ID and trace ID in the import page error state for debugging
- Adds a "Report issue" link that pre-fills the GitHub bug report template with error context
- Refactors import page to use `$api.useQuery` for preview fetching (eliminates manual useEffect data loading)

## Test plan
- [ ] Trigger an import error (e.g. invalid supplier token) and verify request/trace IDs appear
- [ ] Click "Report issue" link and verify GitHub issue form is pre-filled with IDs
- [ ] Verify CORS headers are visible in browser network tab on cross-origin responses
- [ ] Happy-path import still works end-to-end