### PR TITLE
fix(ui): redirect to /onboarding on stale cookie + 404 from /auth/me

### DIFF
--- a/ui/lib/auth.tsx
+++ b/ui/lib/auth.tsx
@@ -47,11 +47,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const fetchAppUser = useCallback(async (accessToken: string) => {
     try {
       setError(false);
-      const { data, error: apiError } = await apiClient.GET("/api/v1/auth/me", {
+      const result = await apiClient.GET("/api/v1/auth/me", {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
-      if (!apiError && data) {
-        setAppUser(data as unknown as AppUser);
+      const status = result.response.status;
+      if (!result.error && result.data) {
+        setAppUser(result.data as unknown as AppUser);
+      } else if (status === 404) {
+        document.cookie = `${ONBOARDED_COOKIE}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+        setAppUser(null);
+        window.location.href = "/onboarding";
       } else {
         setAppUser(null);
         setError(true);


### PR DESCRIPTION
## Summary
- When a user has a stale `ONBOARDED_COOKIE` but their account doesn't exist in the DB (e.g. deleted account re-signing up, or signing in with a new email), the proxy middleware skips the redirect since the cookie exists
- The authenticated layout calls `/auth/me` which returns 404, showing a generic "Something went wrong" error with no way forward
- Fix: detect 404 in `fetchAppUser`, clear the stale cookie, and `window.location.href = "/onboarding"` so the user can complete setup

## Test plan
- [ ] Delete a user's DB record (or sign in with a fresh email that hasn't onboarded)
- [ ] With a stale `cartwise_led` cookie present, navigate to any authenticated page
- [ ] Verify automatic redirect to `/onboarding` instead of "Something went wrong" error
- [ ] Verify normal login flow (existing onboarded user) is unaffected