### PR TITLE
fix(ui): prevent onboarding redirect loop on 404

### DIFF
--- a/ui/lib/auth.tsx
+++ b/ui/lib/auth.tsx
@@ -56,7 +56,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       } else if (status === 404) {
         document.cookie = `${ONBOARDED_COOKIE}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
         setAppUser(null);
-        window.location.href = "/onboarding";
+        if (!window.location.pathname.startsWith("/onboarding")) {
+          window.location.href = "/onboarding";
+        }
       } else {
         setAppUser(null);
         setError(true);


### PR DESCRIPTION
## Summary
- Fixes infinite redirect loop on `/onboarding` page introduced by the stale cookie fix (#180)
- When `fetchAppUser` gets a 404, it now only redirects to `/onboarding` if not already there
- On the onboarding page itself, a 404 is expected (user hasn't called `/auth/onboard` yet) — just set `appUser = null` without redirecting

## Test plan
- [ ] Fresh sign-up flow: should land on `/onboarding`, show "Connecting to Splitwise...", then redirect to Splitwise OAuth
- [ ] No flickering or looping on the onboarding page
- [ ] Stale cookie on authenticated page still redirects to `/onboarding` correctly