### PR TITLE
fix(ui): make avatar square and fill full top-bar cell

### DIFF
--- a/ui/components/top-bar.tsx
+++ b/ui/components/top-bar.tsx
@@ -24,7 +24,7 @@ export function TopBar({ showBack = false, onBack, rightAction }: TopBarProps) {
         <img
           src={appUser.avatar_url}
           alt=""
-          className="h-9 w-9 rounded-full object-cover"
+          className="h-full w-full object-cover"
         />
       ) : (
         <Icon name="account_circle" size={36} />


### PR DESCRIPTION
## Summary
- Remove `rounded-full` and fixed sizing from avatar in top bar
- Avatar now fills the full 48px cell edge-to-edge, matching the back button style

## Test plan
- [ ] Verify avatar displays as square filling the full cell
- [ ] Verify fallback icon still renders correctly when no avatar URL