### PR TITLE
feat(observability): surface git commit SHA across backend and frontend

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -54,6 +54,8 @@ jobs:
           context: ./backend
           push: true
           tags: ${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
 
       - name: Deploy to Cloud Run
         run: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.14-slim
 
+ARG GIT_COMMIT=unknown
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+ENV GIT_COMMIT="${GIT_COMMIT}"
+
 WORKDIR /app
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,7 @@
+import os
 from contextlib import asynccontextmanager
 
+import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -12,10 +14,13 @@ from app.routes import auth, imports, meal_plans, menu_items, orders, users
 from app.services.seed import reconcile_fixtures
 from app.tracing import setup_tracing
 
+GIT_COMMIT = os.environ.get("GIT_COMMIT", "dev")
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     setup_logging()
+    structlog.contextvars.bind_contextvars(git_commit=GIT_COMMIT)
     setup_tracing(app)
     await reconcile_fixtures()
     yield
@@ -36,7 +41,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
-    expose_headers=["X-Request-ID", "X-Trace-ID"],
+    expose_headers=["X-Request-ID", "X-Trace-ID", "X-App-Version"],
 )
 
 # Dev-only: slow down API responses to test loading states
@@ -72,4 +77,4 @@ app.mount("/internal", internal_app)
 
 @app.get("/health")
 async def health():
-    return {"status": "ok"}
+    return {"status": "ok", "version": GIT_COMMIT}

--- a/backend/app/middleware/request_logging.py
+++ b/backend/app/middleware/request_logging.py
@@ -5,6 +5,7 @@ Adds a request ID to every request and logs request/response details.
 Logs mutation request/response bodies for observability.
 """
 
+import os
 import time
 
 import structlog
@@ -19,6 +20,7 @@ logger = structlog.get_logger()
 
 _MAX_BODY_BYTES = 10_240  # 10KB
 _MUTATION_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+_GIT_COMMIT = os.environ.get("GIT_COMMIT", "dev")
 
 
 def _truncate_body(raw: bytes) -> str:
@@ -90,6 +92,7 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         )
 
         response.headers["X-Request-ID"] = request_id
+        response.headers["X-App-Version"] = _GIT_COMMIT
 
         trace_id = trace.get_current_span().get_span_context().trace_id
         if trace_id:

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -10,7 +10,9 @@ from app.models.user import User
 async def test_health(client: AsyncClient):
     response = await client.get("/health")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    body = response.json()
+    assert body["status"] == "ok"
+    assert "version" in body
 
 
 async def test_list_users(client: AsyncClient, test_user: User):

--- a/ui/app/(authenticated)/user/[id]/page.tsx
+++ b/ui/app/(authenticated)/user/[id]/page.tsx
@@ -10,6 +10,8 @@ import { Icon } from "@/components/icon";
 import { ErrorBody } from "@/components/error-body";
 import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog";
 
+const GIT_SHA = process.env.NEXT_PUBLIC_GIT_SHA;
+
 export default function UserPage() {
   const { appUser, signOut, refreshAppUser } = useRequiredAuth();
   const router = useRouter();
@@ -201,6 +203,11 @@ export default function UserPage() {
           </button>
           {settingsOpen && (
             <div className="flex flex-col gap-3 p-3 border-x border-b border-black">
+              {GIT_SHA && (
+                <p className="text-xs text-gray-400 font-mono tracking-wider">
+                  build: {GIT_SHA.slice(0, 7)}
+                </p>
+              )}
               <a
                 href="https://github.com/dostarora97/cartwise/issues/new/choose"
                 target="_blank"

--- a/ui/components/error-body.tsx
+++ b/ui/components/error-body.tsx
@@ -3,6 +3,8 @@
 import { usePathname } from "next/navigation";
 import { type ErrorContext, buildIssueUrl } from "@/lib/errors";
 
+const GIT_SHA = process.env.NEXT_PUBLIC_GIT_SHA;
+
 interface ErrorBodyProps {
   message: string;
   requestId?: string;
@@ -22,12 +24,14 @@ export function ErrorBody({ message, requestId, traceId, status, stack, onRetry 
     status,
     stack,
     pageUrl: typeof window !== "undefined" ? window.location.href : pathname,
+    build: GIT_SHA,
   };
 
   const meta = [
     requestId && `req: ${requestId}`,
     traceId && `trace: ${traceId}`,
     status && `status: ${status}`,
+    GIT_SHA && `build: ${GIT_SHA.slice(0, 7)}`,
   ].filter(Boolean) as string[];
 
   return (

--- a/ui/lib/errors.ts
+++ b/ui/lib/errors.ts
@@ -5,6 +5,7 @@ export interface ErrorContext {
   status?: number;
   stack?: string;
   pageUrl?: string;
+  build?: string;
 }
 
 export type ApiError = Pick<ErrorContext, "message" | "requestId" | "traceId" | "status">;
@@ -34,6 +35,7 @@ export function buildIssueUrl(ctx: ErrorContext): string {
     ctx.pageUrl && `**Page:** ${ctx.pageUrl}`,
     ctx.requestId && `**Request ID:** \`${ctx.requestId}\``,
     ctx.traceId && `**Trace ID:** \`${ctx.traceId}\``,
+    ctx.build && `**Build:** \`${ctx.build}\``,
     ctx.stack && `**Stack:**\n\`\`\`\n${ctx.stack}\n\`\`\``,
   ]
     .filter(Boolean)

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -41,6 +41,9 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_GIT_SHA: process.env.VERCEL_GIT_COMMIT_SHA ?? revision,
+  },
   turbopack: {
     resolveAlias: {
       "../build/polyfills/polyfill-module": "./lib/empty-polyfill.js",


### PR DESCRIPTION
## Summary

- Inject deploy commit SHA into every observability surface for full traceability
- Backend: Dockerfile ARG/ENV, structlog global context field, `X-App-Version` response header, `/health` endpoint version field
- Frontend: `NEXT_PUBLIC_GIT_SHA` env (Vercel auto-provided + local git fallback), short SHA in ErrorBody metadata, full SHA in GitHub issue URL body, short SHA in user settings popover
- CI: passes `--build-arg GIT_COMMIT=${{ github.sha }}` to docker build

Same SHA everywhere since it's a monorepo — one push triggers both Vercel and Cloud Run deploys from the same commit.

Closes #177

## Test plan

- [ ] `GET /health` returns `{"status": "ok", "version": "<sha>"}`
- [ ] Response headers include `X-App-Version: <sha>`
- [ ] Backend structured logs include `git_commit` field
- [ ] Error surfaces show `build: <7-char>` in metadata
- [ ] "Report issue" link includes full SHA in body
- [ ] Settings popover shows `build: <7-char>` above Feedback button
- [ ] Docker image has OCI label `org.opencontainers.image.revision`